### PR TITLE
Parse Version query parameter for XML namespace

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSException.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSException.scala
@@ -5,7 +5,8 @@ import Constants._
 class SQSException(val code: String,
                    val message: String = "See the SQS docs.",
                    val httpStatusCode: Int = 400,
-                   errorType: String = "Sender") extends Exception {
+                   errorType: String = "Sender",
+                   sqsVersion: String = SqsDefaultVersion) extends Exception {
   def toXml(requestId: String) =
     <ErrorResponse>
       <Error>
@@ -15,7 +16,13 @@ class SQSException(val code: String,
         <Detail/>
       </Error>
       <RequestId>{requestId}</RequestId>
-    </ErrorResponse> % SqsNamespace
+    </ErrorResponse> % namespaceFor(sqsVersion)
+
+  private def namespaceFor(version: String) = {
+    if (version == null || version.isEmpty) { version = SqsDefaultVersion }
+
+    new UnprefixedAttribute("xmlns", "http://queue.amazonaws.com/doc/%s/".format(version), Null)
+  }
 }
 
 object SQSException {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -115,11 +115,12 @@ class SQSRestServerBuilder(client: Client,
 
 object Constants {
   val EmptyRequestId = "00000000-0000-0000-0000-000000000000"
-  val SqsNamespace = new UnprefixedAttribute("xmlns", "http://queue.amazonaws.com/doc/2009-02-01/", Null)
+  val SqsDefaultVersion = "2012-11-05"
   val QueueUrlPath = "queue"
   val QueuePath = root / QueueUrlPath / %("QueueName")
   val QueueNameParameter = "QueueName"
   val ReceiptHandleParameter = "ReceiptHandle"
+  val VersionParameter = "Version"
   val VisibilityTimeoutParameter = "VisibilityTimeout"
   val DelayParameter = "DelaySeconds"
   val IdSubParameter = "Id"


### PR DESCRIPTION
See issue https://github.com/adamw/elasticmq/issues/3 that explains why I'm interested in these changes ;0
- Base response off http://queue.amazonaws.com/doc/%s/ where %s
  is supplied by the Version= query parameter
  Default to 2012-11-05, but other standard values are 2011-10-01,
  and 2009-02-01
