### PR TITLE
Add Support for Message Attributes

### DIFF
--- a/core/src/main/scala/org/elasticmq/MessageData.scala
+++ b/core/src/main/scala/org/elasticmq/MessageData.scala
@@ -5,6 +5,7 @@ import org.joda.time.DateTime
 case class MessageData(id: MessageId,
                        deliveryReceipt: Option[DeliveryReceipt],
                        content: String,
+                       messageAttributes: Map[String, String],
                        nextDelivery: MillisNextDelivery,
                        created: DateTime,
                        statistics: MessageStatistics)

--- a/core/src/main/scala/org/elasticmq/NewMessageData.scala
+++ b/core/src/main/scala/org/elasticmq/NewMessageData.scala
@@ -3,4 +3,5 @@ package org.elasticmq
 
 case class NewMessageData(id: Option[MessageId],
                           content: String,
+                          messageAttributes: Map[String, String],
                           nextDelivery: NextDelivery)

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -20,6 +20,7 @@ trait QueueActorStorage {
                              var deliveryReceipt: Option[String],
                              var nextDelivery: Long,
                              content: String,
+                             messageAttributes: Map[String,String],
                              created: DateTime,
                              var firstReceive: Received,
                              var receiveCount: Int)
@@ -32,6 +33,7 @@ trait QueueActorStorage {
       MessageId(id),
       deliveryReceipt.map(DeliveryReceipt(_)),
       content,
+      messageAttributes,
       MillisNextDelivery(nextDelivery),
       created,
       MessageStatistics(firstReceive, receiveCount))
@@ -43,6 +45,7 @@ trait QueueActorStorage {
       messageData.deliveryReceipt.map(_.receipt),
       messageData.nextDelivery.millis,
       messageData.content,
+      messageData.messageAttributes,
       messageData.created,
       messageData.statistics.approximateFirstReceive,
       messageData.statistics.approximateReceiveCount)
@@ -52,6 +55,7 @@ trait QueueActorStorage {
       None,
       newMessageData.nextDelivery.toMillis(nowProvider.nowMillis, queueData.delay.getMillis).millis,
       newMessageData.content,
+      newMessageData.messageAttributes,
       nowProvider.now,
       NeverReceived,
       0)

--- a/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/QueueActorMsgOpsTest.scala
@@ -26,7 +26,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("after persisting a msg it should be found") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val message = createNewMessageData("xyz", "123", MillisNextDelivery(123L))
+    val message = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(123L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -45,7 +45,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
     val maxMessageContent = "x" * 65535
 
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val m = createNewMessageData("xyz", maxMessageContent, MillisNextDelivery(123L))
+    val m = createNewMessageData("xyz", maxMessageContent, Map(), MillisNextDelivery(123L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -67,7 +67,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
     for {
       Right(queueActor1) <- queueManagerActor ? CreateQueue(q1)
       Right(queueActor2) <- queueManagerActor ? CreateQueue(q2)
-      _ <- queueActor1 ? SendMessage(createNewMessageData("xyz", "123", MillisNextDelivery(50L)))
+      _ <- queueActor1 ? SendMessage(createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L)))
 
       // When
 
@@ -82,7 +82,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
     val q2 = createQueueData("q2", MillisVisibilityTimeout(2L))
-    val m = createNewMessageData("xyz", "123", MillisNextDelivery(50L))
+    val m = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L))
 
     for {
       Right(queueActor1) <- queueManagerActor ? CreateQueue(q1)
@@ -100,7 +100,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("next delivery should be updated after receiving") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val m = createNewMessageData("xyz", "123", MillisNextDelivery(50L))
+    val m = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -122,7 +122,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
 
-      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", MillisNextDelivery(50L)))
+      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L)))
 
       // When
       lookupBeforeReceiving <- queueActor ? LookupMessage(MessageId("xyz"))
@@ -148,7 +148,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
-      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", MillisNextDelivery(50L)))
+      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L)))
 
       // When
       received1 <- queueActor ? ReceiveMessages(DefaultVisibilityTimeout, 1, None)
@@ -172,7 +172,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
-      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", MillisNextDelivery(123L)))
+      _ <- queueActor ? SendMessage(createNewMessageData("xyz", "123", Map(), MillisNextDelivery(123L)))
 
       // When
       receiveResult <- queueActor ? ReceiveMessages(DefaultVisibilityTimeout, 1, None)
@@ -185,7 +185,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("increasing next delivery of a msg") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val m = createNewMessageData("xyz", "1234", MillisNextDelivery(123L))
+    val m = createNewMessageData("xyz", "1234", Map(), MillisNextDelivery(123L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -196,15 +196,15 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
       lookupResult <- queueActor ? LookupMessage(MessageId("xyz"))
     } yield {
       // Then
-      lookupResult.map(createNewMessageData(_)) should be (Some(createNewMessageData("xyz", "1234", MillisNextDelivery(150L))))
+      lookupResult.map(createNewMessageData(_)) should be (Some(createNewMessageData("xyz", "1234", Map(), MillisNextDelivery(150L))))
     }
   }
 
   waitTest("decreasing next delivery of a msg") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))   // Initially m2 should be delivered after m1
-    val m1 = createNewMessageData("xyz1", "1234", MillisNextDelivery(150L))
-    val m2 = createNewMessageData("xyz2", "1234", MillisNextDelivery(200L))
+    val m1 = createNewMessageData("xyz1", "1234", Map(), MillisNextDelivery(150L))
+    val m2 = createNewMessageData("xyz2", "1234", Map(), MillisNextDelivery(200L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -225,7 +225,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("msg should be deleted") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val m1 = createNewMessageData("xyz", "123", MillisNextDelivery(50L))
+    val m1 = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -244,7 +244,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("msg statistics should be updated") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val m1 = createNewMessageData("xyz", "123", MillisNextDelivery(50L))
+    val m1 = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(50L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -266,7 +266,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("should receive at most as much messages as given") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val msgs = (for { i <- 1 to 5 } yield createNewMessageData("xyz" + i, "123", MillisNextDelivery(100))).toList
+    val msgs = (for { i <- 1 to 5 } yield createNewMessageData("xyz" + i, "123", Map(), MillisNextDelivery(100))).toList
     val List(m1, m2, m3, m4, m5) = msgs
 
     for {
@@ -292,7 +292,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("should receive as much messages as possible") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val msgs = (for { i <- 1 to 3 } yield createNewMessageData("xyz" + i, "123", MillisNextDelivery(100))).toList
+    val msgs = (for { i <- 1 to 3 } yield createNewMessageData("xyz" + i, "123", Map(), MillisNextDelivery(100))).toList
     val List(m1, m2, m3) = msgs
 
     for {
@@ -333,7 +333,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("should wait until messages are available") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val msg = createNewMessageData("xyz", "123", MillisNextDelivery(200L))
+    val msg = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(200L))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)
@@ -353,7 +353,7 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("multiple futures should wait until messages are available, and receive the message only once") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val msg = createNewMessageData("xyz", "123", MillisNextDelivery(100))
+    val msg = createNewMessageData("xyz", "123", Map(), MillisNextDelivery(100))
     val start = System.currentTimeMillis()
 
     for {
@@ -380,8 +380,8 @@ class QueueActorMsgOpsTest extends ActorTest with QueueManagerForEachTest with D
   waitTest("multiple futures should wait until messages are available, and receive all sent messages") {
     // Given
     val q1 = createQueueData("q1", MillisVisibilityTimeout(1L))
-    val msg1 = createNewMessageData("xyz1", "123a", MillisNextDelivery(100))
-    val msg2 = createNewMessageData("xyz2", "123b", MillisNextDelivery(100))
+    val msg1 = createNewMessageData("xyz1", "123a", Map(), MillisNextDelivery(100))
+    val msg2 = createNewMessageData("xyz2", "123b", Map(), MillisNextDelivery(100))
 
     for {
       Right(queueActor) <- queueManagerActor ? CreateQueue(q1)

--- a/core/src/test/scala/org/elasticmq/actor/QueueActorQueueOpsTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/QueueActorQueueOpsTest.scala
@@ -60,17 +60,17 @@ class QueueActorQueueOpsTest extends ActorTest with QueueManagerForEachTest with
     // Given
     val queue = createQueueData("q1", MillisVisibilityTimeout(100L))
 
-    val m1 = createNewMessageData("m1", "123", MillisNextDelivery(120L))
-    val m2 = createNewMessageData("m2", "123", MillisNextDelivery(121L))
-    val m3 = createNewMessageData("m3", "123", MillisNextDelivery(122L))
-    val m4 = createNewMessageData("m4", "123", MillisNextDelivery(123L))
+    val m1 = createNewMessageData("m1", "123", Map(), MillisNextDelivery(120L))
+    val m2 = createNewMessageData("m2", "123", Map(), MillisNextDelivery(121L))
+    val m3 = createNewMessageData("m3", "123", Map(), MillisNextDelivery(122L))
+    val m4 = createNewMessageData("m4", "123", Map(), MillisNextDelivery(123L))
 
-    val m5 = createNewMessageData("m5", "123", MillisNextDelivery(120L))
-    val m6 = createNewMessageData("m6", "123", MillisNextDelivery(120L))
+    val m5 = createNewMessageData("m5", "123", Map(), MillisNextDelivery(120L))
+    val m6 = createNewMessageData("m6", "123", Map(), MillisNextDelivery(120L))
 
-    val m7 = createNewMessageData("m7", "123", MillisNextDelivery(127L))
-    val m8 = createNewMessageData("m8", "123", MillisNextDelivery(128L))
-    val m9 = createNewMessageData("m9", "123", MillisNextDelivery(129L))
+    val m7 = createNewMessageData("m7", "123", Map(), MillisNextDelivery(127L))
+    val m8 = createNewMessageData("m8", "123", Map(), MillisNextDelivery(128L))
+    val m9 = createNewMessageData("m9", "123", Map(), MillisNextDelivery(129L))
 
     nowProvider.mutableNowMillis.set(123L)
 

--- a/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
+++ b/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
@@ -9,13 +9,13 @@ trait DataCreationHelpers {
   def createQueueData(name: String, defaultVisibilityTimeout: MillisVisibilityTimeout) =
     QueueData(name, defaultVisibilityTimeout, Duration.ZERO, Duration.ZERO, new DateTime(0), new DateTime(0))
 
-  def createMessageData(id: String, content: String, nextDelivery: MillisNextDelivery,
+  def createMessageData(id: String, content: String, messageAttributes: Map[String,String], nextDelivery: MillisNextDelivery,
                         deliveryReceipt: Option[DeliveryReceipt] = None) =
-    MessageData(MessageId(id), deliveryReceipt, content, nextDelivery, new DateTime(0), MessageStatistics(NeverReceived, 0))
+    MessageData(MessageId(id), deliveryReceipt, content, messageAttributes, nextDelivery, new DateTime(0), MessageStatistics(NeverReceived, 0))
 
-  def createNewMessageData(id: String, content: String, nextDelivery: MillisNextDelivery) =
-    NewMessageData(Some(MessageId(id)), content, nextDelivery)
+  def createNewMessageData(id: String, content: String, messageAttributes: Map[String, String], nextDelivery: MillisNextDelivery) =
+    NewMessageData(Some(MessageId(id)), content, messageAttributes, nextDelivery)
 
   def createNewMessageData(messageData: MessageData) =
-    NewMessageData(Some(messageData.id), messageData.content, messageData.nextDelivery)
+    NewMessageData(Some(messageData.id), messageData.content, messageData.messageAttributes, messageData.nextDelivery)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -67,7 +67,7 @@ object Dependencies {
   val mockito       = "org.mockito"               % "mockito-core"          % "1.9.5"
   val awaitility    = "com.jayway.awaitility"     % "awaitility-scala"      % "1.5.0"
 
-  val amazonJavaSdk = "com.amazonaws"             % "aws-java-sdk"          % "1.7.7" exclude ("commons-logging", "commons-logging")
+  val amazonJavaSdk = "com.amazonaws"             % "aws-java-sdk"          % "1.7.11" exclude ("commons-logging", "commons-logging")
 
   val akka2Version          = "2.3.3"
   val akka2Actor            = "com.typesafe.akka" %% "akka-actor"           % akka2Version

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/AttributesModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/AttributesModule.scala
@@ -3,6 +3,7 @@ package org.elasticmq.rest.sqs
 trait AttributesModule {
   val attributeNamesReader = new AttributeNamesReader
   val attributesToXmlConverter = new AttributesToXmlConverter
+  val messageAttributesToXmlConverter = new MessageAttributesToXmlConverter
   val attributeValuesCalculator = new AttributeValuesCalculator
   val attributeNameAndValuesReader = new AttributeNameAndValuesReader
 
@@ -37,6 +38,19 @@ trait AttributesModule {
           <Name>{a._1}</Name>
           <Value>{a._2}</Value>
         </Attribute>)
+    }
+  }
+
+  class MessageAttributesToXmlConverter {
+    def convert(attributes: List[(String, String)]) = {
+      attributes.map(a =>
+        <MessageAttribute>
+          <Name>{a._1}</Name>
+          <Value>
+            <DataType>String</DataType>
+            <StringValue>{a._2}</StringValue>
+          </Value>
+        </MessageAttribute>)
     }
   }
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -51,7 +51,7 @@ trait ReceiveMessageDirectives { this: ElasticMQDirectives with AttributesModule
 
             def calculateAttributeValues(msg: MessageData): List[(String, String)] = {
               import AttributeValuesCalculator.Rule
-
+              
               attributeValuesCalculator.calculate(attributeNames,
                 Rule(SentTimestampAttribute, ()=>msg.created.getMillis.toString),
                 Rule(ApproximateReceiveCountAttribute, ()=>msg.statistics.approximateReceiveCount.toString),
@@ -74,6 +74,8 @@ trait ReceiveMessageDirectives { this: ElasticMQDirectives with AttributesModule
                       <MD5OfBody>{md5Digest(msg.content)}</MD5OfBody>
                       <Body>{XmlUtil.convertTexWithCRToNodeSeq(msg.content)}</Body>
                       {attributesToXmlConverter.convert(calculateAttributeValues(msg))}
+                      <MD5OfMessageAttributes>{md5AttributeDigest(msg.messageAttributes)}</MD5OfMessageAttributes> // TODO: Only include if message attributes
+                      {messageAttributesToXmlConverter.convert(msg.messageAttributes.toList)} // TODO: Filter to only requested attributes
                     </Message> }.toList}
                   </ReceiveMessageResult>
                   <ResponseMetadata>

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
@@ -13,9 +13,10 @@ trait SendMessageBatchDirectives { this: ElasticMQDirectives with SendMessageDir
           verifyMessagesNotTooLong(parameters)
 
           val resultsFuture = batchRequest(SendMessageBatchPrefix, parameters) { (messageData, id) =>
-            doSendMessage(queueActor, messageData).map { case (message, digest) =>
+            doSendMessage(queueActor, messageData).map { case (message, digest, messageAttributeDigest) =>
               <SendMessageBatchResultEntry>
                 <Id>{id}</Id>
+                <MD5OfMessageAttributes>{messageAttributeDigest}</MD5OfMessageAttributes> // TODO: Only send if message attributes included
                 <MD5OfMessageBody>{digest}</MD5OfMessageBody>
                 <MessageId>{message.id.id}</MessageId>
               </SendMessageBatchResultEntry>


### PR DESCRIPTION
SQS now includes the ability to include `Message Attributes` when posting messages to queue.  The complete AWS documentation is available [here](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSMessageAttributes.html#SQSMessageAttributesNTV).  This pull request implements base support for message attributes.  The largest current restriction is that we only accept attributes of String type.  All test cases should be passing with these modifications.
