### PR TITLE
Fix batch request handling of sub.sub.subKeys

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
@@ -56,7 +56,7 @@ object BatchRequestsModule {
    */
   def subParametersMaps(prefix: String, parameters: Map[String, String]): List[Map[String, String]] = {
     val subParameters = collection.mutable.Map[String, Map[String, String]]()
-    val keyRegexp = (Pattern.quote(prefix) + "\\.(.+)\\.(.+)").r
+    val keyRegexp = (Pattern.quote(prefix) + "\\.([^.]+)\\.(.+)").r
     parameters.foreach{ case (key, value) =>
       keyRegexp.findFirstMatchIn(key).map { keyMatch =>
         val discriminator = keyMatch.group(1)

--- a/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
+++ b/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
@@ -14,7 +14,8 @@ class BatchRequestsModuleTest extends FunSuite with MustMatchers {
       "SomePrefix.2.Key21" -> "Value21",
       "SomePrefixAndMore.1.Key" -> "Value",
       "SomePrefix.2.Key22" -> "Value22",
-      "SomePrefix.4.Key41" -> "Value41"
+      "SomePrefix.4.Key41" -> "Value41",
+      "SomePrefix.4.Multi.Key.1" -> "ValueMulti"
     )
 
     // When
@@ -24,6 +25,6 @@ class BatchRequestsModuleTest extends FunSuite with MustMatchers {
     subParameters must have length (3)
     subParameters must contain (Map("Key1" -> "Value1", "Key2" -> "Value2", "Key3" -> "Value3"))
     subParameters must contain (Map("Key21" -> "Value21", "Key22" -> "Value22"))
-    subParameters must contain (Map("Key41" -> "Value41"))
+    subParameters must contain (Map("Key41" -> "Value41","Multi.Key.1" -> "ValueMulti"))
   }
 }


### PR DESCRIPTION
Limit subKey to not include periods; this is important for sub.sub.subKeys, such as Message Attributes.

E.g. given prefix `SendMessageBatchRequestEntry` and parameters:

```
SendMessageBatchRequestEntry.1.MessageAttribute.1.Value.StringValue -> index
SendMessageBatchRequestEntry.1.MessageBody -> {}
SendMessageBatchRequestEntry.1.Id -> 0
Version -> 2012-11-05
```

we want:

```
Map(Id -> 0, MessageAttribute.1.Value.StringValue -> index, MessageBody -> {}, Id -> 0)
```

I've added a test case to this effect.
