### PR TITLE
Added stubbed SenderId attribute

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -13,11 +13,12 @@ trait ReceiveMessageDirectives { this: ElasticMQDirectives with AttributesModule
     val SentTimestampAttribute = "SentTimestamp"
     val ApproximateReceiveCountAttribute = "ApproximateReceiveCount"
     val ApproximateFirstReceiveTimestampAttribute = "ApproximateFirstReceiveTimestamp"
+    val SenderIdAttribute = "SenderId"
     val MaxNumberOfMessagesAttribute = "MaxNumberOfMessages"
     val WaitTimeSecondsAttribute = "WaitTimeSeconds"
 
     val AllAttributeNames = SentTimestampAttribute :: ApproximateReceiveCountAttribute ::
-      ApproximateFirstReceiveTimestampAttribute :: Nil
+      ApproximateFirstReceiveTimestampAttribute :: SenderIdAttribute :: Nil
   }
 
   val receiveMessage = {
@@ -53,6 +54,7 @@ trait ReceiveMessageDirectives { this: ElasticMQDirectives with AttributesModule
               import AttributeValuesCalculator.Rule
               
               attributeValuesCalculator.calculate(attributeNames,
+                Rule(SenderIdAttribute, ()=> "127.0.0.1"),
                 Rule(SentTimestampAttribute, ()=>msg.created.getMillis.toString),
                 Rule(ApproximateReceiveCountAttribute, ()=>msg.statistics.approximateReceiveCount.toString),
                 Rule(ApproximateFirstReceiveTimestampAttribute,


### PR DESCRIPTION
SenderId should be present when All is requested:

http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html

The documentation states that the SenderId should return the AWS account number (or the IP address, if anonymous access is allowed) of the sender.

So I use "127.0.0.1" as the stubbed value for this.
