### PR TITLE
#133 add note about config in embedded mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ You can also provide a custom `ActorSystem`; for details see the javadocs.
 
 Embedded ElasticMQ can be used from any JVM-based language (Java, Scala, etc.).
 
+(Note that the embedded server does not load any configuration files, so you cannot automatically create queues on startup as described above. You can of course create queues programmatically.)
+
 Using the Amazon Java SDK to access an ElasticMQ Server
 -------------------------------------------------------
 


### PR DESCRIPTION
It was not clear to me that embedded mode does not load config. The current Readme suggests that it will, to my reading, which confused me for a while. I thought I had named my config file wrong and spent a while trying to debug the config code.