### PR TITLE
expose the port that the software is listening on. This fixes a probl…

### DIFF
--- a/native-server/run-native-image/Dockerfile
+++ b/native-server/run-native-image/Dockerfile
@@ -4,4 +4,5 @@ FROM alpine:3.10.0
 RUN apk add --no-cache tini
 COPY out /opt/docker/out
 RUN chmod +x /opt/docker/out
+EXPOSE 9324/tcp
 ENTRYPOINT [ "/sbin/tini", "--", "/opt/docker/out" ]


### PR DESCRIPTION
I had to do something unusual when working with this image because it doesn't expose the port it's using to listen for connections.

This meant I had to add a port declaration to the docker-compose service for port 9324 and then I could connect to the port. Even though I should have been able to do so without having to manually declare the port.

Perhaps this was because I was running behind a front end proxy (nginx). But I think that the EXPOSE command is missing and perhaps adding it will solve some connectivity issues.