### PR TITLE
Preserve ordering in batch requests.

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
@@ -73,6 +73,6 @@ object BatchRequestsModule {
         }
     }
 
-    subParameters.values.map(_.toMap).toList
+    subParameters.toList.sortBy(_._1).map(_._2)
   }
 }

--- a/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
+++ b/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
@@ -27,4 +27,29 @@ class BatchRequestsModuleTest extends FunSuite with Matchers {
     subParameters should contain(Map("Key21" -> "Value21", "Key22" -> "Value22"))
     subParameters should contain(Map("Key41" -> "Value41", "Multi.Key.1" -> "ValueMulti"))
   }
+
+  test("should preserve the order for sub parameters") {
+    // Given
+    val parameters = Map(
+      "WihtoutPrefix.1.Key" -> "Value",
+      "SomePrefix.1.Key1" -> "Value1",
+      "SomePrefix.1.Key2" -> "Value2",
+      "SomePrefix.1.Key3" -> "Value3",
+      "SomePrefix.2.Key21" -> "Value21",
+      "SomePrefixAndMore.1.Key" -> "Value",
+      "SomePrefix.2.Key22" -> "Value22",
+      "SomePrefix.4.Key41" -> "Value41",
+      "SomePrefix.4.Multi.Key.1" -> "ValueMulti"
+    )
+
+    // When
+    val subParameters = BatchRequestsModule.subParametersMaps("SomePrefix", parameters)
+
+    // Then
+    subParameters should contain theSameElementsInOrderAs List(
+      Map("Key1" -> "Value1", "Key2" -> "Value2", "Key3" -> "Value3"),
+      Map("Key21" -> "Value21", "Key22" -> "Value22"),
+      Map("Key41" -> "Value41", "Multi.Key.1" -> "ValueMulti")
+    )
+  }
 }


### PR DESCRIPTION
Sending a batch of messages to a queue may result in a not-ordered processing of the received messages which may cause not expected behaviours in the case of FIFO queues (see #267).

The `SendMessageBatchDirectives` attempts to retrieve the list of provided parameters via the `BatchRequestsModule` which uses internally a `mutable.Map` to store handled parameters. This result-map does not maintain the order of the entry parameter list (please see the provided test). This PR aims to modify the `BatchRequestsModule::subParametersMaps` method in such a way that it preserves the order by sorting the parameters accordingly to the discriminator.