### PR TITLE
Fix ordering in batch requests greater than or equal 10.

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/BatchRequestsModule.scala
@@ -73,6 +73,6 @@ object BatchRequestsModule {
         }
     }
 
-    subParameters.toList.sortBy(_._1).map(_._2)
+    subParameters.toList.sortBy(_._1.toInt).map(_._2)
   }
 }

--- a/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
+++ b/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/BatchRequestsModuleTest.scala
@@ -3,6 +3,8 @@ package org.elasticmq.rest.sqs
 import org.scalatest.FunSuite
 import org.scalatest.Matchers
 
+import scala.util.Random
+
 class BatchRequestsModuleTest extends FunSuite with Matchers {
   test("should correctly find sub parameters") {
     // Given
@@ -51,5 +53,37 @@ class BatchRequestsModuleTest extends FunSuite with Matchers {
       Map("Key21" -> "Value21", "Key22" -> "Value22"),
       Map("Key41" -> "Value41", "Multi.Key.1" -> "ValueMulti")
     )
+  }
+
+  test("should preserve the order for sub parameters with a size greater than 10") {
+    // Given
+    val prefix = "SomePrefix"
+
+    // SomePrefix.1.Key1 -> Value1-1
+    // SomePrefix.1.Key2 -> Value1-2
+    // SomePrefix.1.Key3 -> Value1-3
+    // SomePrefix.1.Key4 -> Value1-4
+    // ... not sorted to SomePrefix.20.Key4 -> Value20-4
+    val parameters = Random
+      .shuffle(for {
+        i <- 1 to 20
+        j <- 1 to 4
+      } yield s"$prefix.$i.Key$j" -> s"Value$i-$j")
+      .toMap
+
+    // When
+    val subParameters = BatchRequestsModule.subParametersMaps(prefix, parameters)
+
+    // Then
+    // Key4 -> Value1-4
+    // Key1 -> Value1-1
+    // Key3 -> Value1-3
+    // Key2 -> Value1-2
+    // sorted by discriminator, whereas the values for a discriminator are not sorted
+    for (i <- 1 to 20) {
+      subParameters(i - 1) should contain theSameElementsAs (1 to 4).map { j =>
+        s"Key$j" -> s"Value$i-$j"
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes the sorting introduced in #268  for batches with a size greater than or equal 10. 

The currently implemented sorting mechanism relays on a `String`-sort which may lead to incorrect sorting behaviour for numbers greater than or equal 10. This PR will fix the sorting by transforming the discriminator to a `Int` before the sorting applies. In the special case of AWS SQS we should be able to do this without to worry about `NumberFormatException`s, see [SendMessageBatch](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessageBatch.html
).

Please note that AWS SQS has currently no support for batches with a size greater than 10 by design.