### PR TITLE
Allow delay seconds of 0 on FIFO queues + expand error messages

### DIFF
--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -426,37 +426,33 @@ class AmazonJavaSdkTestSuite extends FunSuite with Matchers with BeforeAndAfter 
     val regularQueueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
 
     // An illegal character
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageGroupId("æ"))
-    }
+    assertInvalidParameterException("MessageGroupId")(
+      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageGroupId("æ")))
 
     // More than 128 characters
     val id = (for (_ <- 0 to 300) yield "1").mkString("")
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageGroupId(id))
-    }
+    assertInvalidParameterException("MessageGroupId")(
+      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageGroupId(id)))
 
     // Message group IDs are required for fifo queues
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body"))
-    }
+    assertMissingParameterException("MessageGroupId")(
+      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body")))
 
     // Regular queues don't allow message groups
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(regularQueueUrl, "A body").withMessageGroupId("group-1"))
-    }
+    assertInvalidParameterQueueTypeException("MessageGroupId")(
+      client.sendMessage(new SendMessageRequest(regularQueueUrl, "A body").withMessageGroupId("group-1")))
   }
 
   test("FIFO queues do not support delaying individual messages") {
     val queueUrl = createFifoQueue()
-    an[AmazonSQSException] shouldBe thrownBy {
+    assertInvalidParameterException("DelaySeconds")(
       client.sendMessage(
         new SendMessageRequest(queueUrl, "body")
           .withMessageDeduplicationId("1")
           .withMessageGroupId("1")
           .withDelaySeconds(10)
       )
-    }
+    )
 
     val result = client.sendMessageBatch(
       new SendMessageBatchRequest(queueUrl).withEntries(
@@ -466,6 +462,14 @@ class AmazonJavaSdkTestSuite extends FunSuite with Matchers with BeforeAndAfter 
     )
     result.getSuccessful should have size 1
     result.getFailed should have size 1
+
+    // Sanity check that a 0 delay seconds value is accepted
+    client.sendMessage(
+      new SendMessageRequest(queueUrl, "body")
+        .withMessageDeduplicationId("1")
+        .withMessageGroupId("1")
+        .withDelaySeconds(0)
+    )
   }
 
   test("FIFO provided message deduplication ids should take priority over content based deduplication") {
@@ -493,20 +497,26 @@ class AmazonJavaSdkTestSuite extends FunSuite with Matchers with BeforeAndAfter 
     val regularQueueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
 
     // An illegal character
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageDeduplicationId("æ"))
-    }
+    assertInvalidParameterException("MessageDeduplicationId")(
+      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body")
+        .withMessageGroupId("groupId1")
+        .withMessageDeduplicationId("æ")
+      )
+    )
 
     // More than 128 characters
     val id = (for (_ <- 0 to 300) yield "1").mkString("")
-    an[AmazonSQSException] shouldBe thrownBy {
-      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body").withMessageDeduplicationId(id))
-    }
+    assertInvalidParameterException("MessageDeduplicationId")(
+      client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body")
+        .withMessageGroupId("groupId1")
+        .withMessageDeduplicationId(id)
+      )
+    )
 
     // Regular queues don't allow message deduplication
-    an[AmazonSQSException] shouldBe thrownBy {
+    assertInvalidParameterQueueTypeException("MessageDeduplicationId")(
       client.sendMessage(new SendMessageRequest(regularQueueUrl, "A body").withMessageDeduplicationId("dedup-1"))
-    }
+    )
   }
 
   test("FIFO queues need a content based deduplication strategy when no message deduplication ids are provided") {
@@ -1877,6 +1887,25 @@ class AmazonJavaSdkTestSuite extends FunSuite with Matchers with BeforeAndAfter 
     // Then
     resultStrict.isLeft should be(true)
     resultRelaxed.isRight should be(true)
+  }
+
+  def assertInvalidParameterException(parameterName: String)(f: => Any): Unit = {
+    val ex = the[AmazonSQSException] thrownBy f
+    ex.getErrorCode should be("InvalidParameterValue")
+    ex.getMessage should include(parameterName)
+  }
+
+  def assertInvalidParameterQueueTypeException(parameterName: String)(f: => Any): Unit = {
+    val ex = the[AmazonSQSException] thrownBy f
+    ex.getErrorCode should be("InvalidParameterValue")
+    ex.getMessage should include(parameterName)
+    ex.getMessage should include("The request include parameter that is not valid for this queue type")
+  }
+
+  def assertMissingParameterException(parameterName: String)(f: => Any): Unit = {
+    val ex = the[AmazonSQSException] thrownBy f
+    ex.getErrorCode should be("MissingParameter")
+    ex.getMessage should include(s"The request must contain the parameter $parameterName.")
   }
 
   def appendRange(builder: StringBuilder, start: Int, end: Int): Unit = {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -39,10 +39,12 @@ trait ReceiveMessageDirectives {
 
         val receiveRequestAttemptId = p.get(ReceiveRequestAttemptIdAttribute) match {
           // ReceiveRequestAttemptIdAttribute is only supported for FIFO queues
-          case Some(_) if !queueData.isFifo => throw SQSException.invalidParameterValue
+          case Some(v) if !queueData.isFifo =>
+            throw SQSException.invalidQueueTypeParameter(v, ReceiveRequestAttemptIdAttribute)
 
           // Validate values
-          case Some(attemptId) if !isValidFifoPropertyValue(attemptId) => throw SQSException.invalidParameterValue
+          case Some(attemptId) if !isValidFifoPropertyValue(attemptId) =>
+            throw SQSException.invalidAlphanumericalPunctualParameterValue(attemptId, ReceiveRequestAttemptIdAttribute)
 
           // The docs at https://docs.aws.amazon.com/cli/latest/reference/sqs/receive-message.html quote:
           //   > If a caller of the receive-message action doesn't provide a ReceiveRequestAttemptId , Amazon SQS

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSException.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSException.scala
@@ -1,11 +1,17 @@
 package org.elasticmq.rest.sqs
 
+import scala.xml.Elem
+
 import Constants._
 
-class SQSException(val code: String, val httpStatusCode: Int = 400, errorType: String = "Sender") extends Exception {
-  val message: String = code + "; see the SQS docs."
+class SQSException(
+  val code: String,
+  val httpStatusCode: Int = 400,
+  errorType: String = "Sender",
+  errorMessage: Option[String] = None) extends Exception {
+  val message: String = errorMessage.getOrElse(code + "; see the SQS docs.")
 
-  def toXml(requestId: String) =
+  def toXml(requestId: String): Elem =
     <ErrorResponse>
       <Error>
         <Type>{errorType}</Type>
@@ -18,7 +24,50 @@ class SQSException(val code: String, val httpStatusCode: Int = 400, errorType: S
 }
 
 object SQSException {
-  def invalidParameterValue = new SQSException(InvalidParameterValueErrorName)
-  def nonExistentQueue =
+  /** Indicates that a parameter was sent to a queue whose type does not support it */
+  def invalidQueueTypeParameter(
+    value: String,
+    parameterName: String
+  ): SQSException =
+    invalidParameter(
+      value,
+      parameterName,
+      Some("The request include parameter that is not valid for this queue type")
+    )
+
+  /** Indicates that the given value for the given parameter name is not a max 128 alphanumerical (incl punctuation) */
+  def invalidAlphanumericalPunctualParameterValue(
+    value: String,
+    parameterName: String
+  ): SQSException =
+    invalidParameter(
+      value,
+      parameterName,
+      Some(s"$parameterName can only include alphanumeric and punctuation characters. 1 to 128 in length.")
+    )
+
+  /** Indicates that the given value for the given parameter name is invalid */
+  def invalidParameter(
+    value: String,
+    parameterName: String,
+    reason: Option[String] = None
+  ): SQSException = {
+    val valueMessage = s"Value $value for parameter $parameterName is invalid."
+    val errorMessage = reason.map(r => s"$valueMessage $r").getOrElse(valueMessage)
+    new SQSException(InvalidParameterValueErrorName, errorMessage = Some(errorMessage))
+  }
+
+  /** Generic invalid parameter value exception without any further reason */
+  def invalidParameterValue: SQSException = new SQSException(InvalidParameterValueErrorName)
+
+  /** Indicates that the request is missing the given parameter name */
+  def missingParameter(parameterName: String): SQSException =
+    new SQSException(
+      MissingParameterName,
+      errorMessage = Some(s"The request must contain the parameter $parameterName.")
+    )
+
+  /** Indicates a queue does not exist */
+  def nonExistentQueue: SQSException =
     new SQSException("AWS.SimpleQueueService.NonExistentQueue")
 }

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -232,6 +232,7 @@ object Constants {
   val QueueArnAttribute = "QueueArn"
   val IdSubParameter = "Id"
   val InvalidParameterValueErrorName = "InvalidParameterValue"
+  val MissingParameterName = "MissingParameter"
   val QueueUrlContext = "queue"
 }
 


### PR DESCRIPTION
Addresses #273

I took the liberty to also expand some of the existing error messaging (inline with what AWS returns of course) as it's sometimes confusing why a FIFO request might be failing.