### PR TITLE
More precise creation timestamp for internal messages

### DIFF
--- a/core/src/main/scala/org/elasticmq/NewMessageData.scala
+++ b/core/src/main/scala/org/elasticmq/NewMessageData.scala
@@ -6,5 +6,6 @@ case class NewMessageData(
     messageAttributes: Map[String, MessageAttribute],
     nextDelivery: NextDelivery,
     messageGroupId: Option[String],
-    messageDeduplicationId: Option[String]
+    messageDeduplicationId: Option[String],
+    orderIndex: Int
 )

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -1,11 +1,11 @@
 package org.elasticmq.actor.queue
 
 import akka.actor.ActorRef
+import org.elasticmq.actor.queue.ReceiveRequestAttemptCache.ReceiveFailure.{Expired, Invalid}
 import org.elasticmq.actor.reply._
 import org.elasticmq.msg.{DeleteMessage, LookupMessage, ReceiveMessages, SendMessage, UpdateVisibilityTimeout, _}
 import org.elasticmq.util.{Logging, NowProvider}
 import org.elasticmq.{MessageData, MessageId, MillisNextDelivery, NewMessageData, _}
-import org.elasticmq.actor.queue.ReceiveRequestAttemptCache.ReceiveFailure.{Expired, Invalid}
 
 trait QueueActorMessageOps extends Logging {
   this: QueueActorStorage =>
@@ -61,7 +61,7 @@ trait QueueActorMessageOps extends Logging {
     * @return                Whether the new message counts as a duplicate
     */
   private def isDuplicate(newMessage: NewMessageData, queueMessage: InternalMessage): Boolean = {
-    lazy val isWithinDeduplicationWindow = queueMessage.created.plusMinutes(5).isAfter(nowProvider.now)
+    lazy val isWithinDeduplicationWindow = queueMessage.created.dateTime.plusMinutes(5).isAfter(nowProvider.now)
     newMessage.messageDeduplicationId == queueMessage.messageDeduplicationId && isWithinDeduplicationWindow
   }
 

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -61,7 +61,7 @@ trait QueueActorMessageOps extends Logging {
     * @return                Whether the new message counts as a duplicate
     */
   private def isDuplicate(newMessage: NewMessageData, queueMessage: InternalMessage): Boolean = {
-    lazy val isWithinDeduplicationWindow = queueMessage.created.dateTime.plusMinutes(5).isAfter(nowProvider.now)
+    lazy val isWithinDeduplicationWindow = queueMessage.created.plusMinutes(5).isAfter(nowProvider.now)
     newMessage.messageDeduplicationId == queueMessage.messageDeduplicationId && isWithinDeduplicationWindow
   }
 

--- a/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
@@ -1,33 +1,23 @@
 package org.elasticmq.actor.queue
 
 import org.elasticmq.NeverReceived
-import org.elasticmq.actor.queue.InternalMessage.PreciseDateTime
+import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 
 import scala.collection.mutable
 
 class InternalMessageSpec extends FunSuite with Matchers {
-  test("PreciseDateTime should be comparable") {
-    PreciseDateTime().compareTo(PreciseDateTime()) shouldBe -1
-  }
-
-  test("PreciseDateTime's created at the same instant should be comparable using a more granular precision") {
-    val first = PreciseDateTime()
-    val second = first.copy(
-      nanoSeconds = first.nanoSeconds + 1
-    )
-
-    first.compareTo(second) shouldBe -1
-  }
-
   test("Internal FIFO message should be ordered by their creation time") {
+    val freezedDateTime = new DateTime()
+
     val first = InternalMessage(
       id = "id",
       deliveryReceipts = mutable.Buffer.empty,
       nextDelivery = 0L,
       content = "content",
       messageAttributes = Map.empty,
-      created = PreciseDateTime(),
+      created = freezedDateTime,
+      orderIndex = 100,
       firstReceive = NeverReceived,
       receiveCount = 0,
       isFifo = true,
@@ -36,7 +26,32 @@ class InternalMessageSpec extends FunSuite with Matchers {
     )
 
     val second = first.copy(
-      created = PreciseDateTime()
+      created = freezedDateTime.plusMillis(1)
+    )
+
+    first.compareTo(second) shouldBe 1
+  }
+
+  test("Internal FIFO messages should be ordered by their orderIndex if they share the same creation time") {
+    val freezedDateTime = new DateTime()
+
+    val first = InternalMessage(
+      id = "id",
+      deliveryReceipts = mutable.Buffer.empty,
+      nextDelivery = 0L,
+      content = "content",
+      messageAttributes = Map.empty,
+      created = freezedDateTime,
+      orderIndex = 100,
+      firstReceive = NeverReceived,
+      receiveCount = 0,
+      isFifo = true,
+      messageGroupId = None,
+      messageDeduplicationId = None
+    )
+
+    val second = first.copy(
+      orderIndex = first.orderIndex + 1
     )
 
     first.compareTo(second) shouldBe 1

--- a/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
@@ -1,0 +1,44 @@
+package org.elasticmq.actor.queue
+
+import org.elasticmq.NeverReceived
+import org.elasticmq.actor.queue.InternalMessage.PreciseDateTime
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.collection.mutable
+
+class InternalMessageSpec extends FunSuite with Matchers {
+  test("PreciseDateTime should be comparable") {
+    PreciseDateTime().compareTo(PreciseDateTime()) shouldBe -1
+  }
+
+  test("PreciseDateTime's created at the same instant should be comparable using a more granular precision") {
+    val first = PreciseDateTime()
+    val second = first.copy(
+      nanoSeconds = first.nanoSeconds + 1
+    )
+
+    first.compareTo(second) shouldBe -1
+  }
+
+  test("Internal FIFO message should be ordered by their creation time") {
+    val first = InternalMessage(
+      id = "id",
+      deliveryReceipts = mutable.Buffer.empty,
+      nextDelivery = 0L,
+      content = "content",
+      messageAttributes = Map.empty,
+      created = PreciseDateTime(),
+      firstReceive = NeverReceived,
+      receiveCount = 0,
+      isFifo = true,
+      messageGroupId = None,
+      messageDeduplicationId = None
+    )
+
+    val second = first.copy(
+      created = PreciseDateTime()
+    )
+
+    first.compareTo(second) shouldBe -1
+  }
+}

--- a/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/InternalMessageSpec.scala
@@ -39,6 +39,6 @@ class InternalMessageSpec extends FunSuite with Matchers {
       created = PreciseDateTime()
     )
 
-    first.compareTo(second) shouldBe -1
+    first.compareTo(second) shouldBe 1
   }
 }

--- a/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
@@ -2,7 +2,6 @@ package org.elasticmq.actor.queue
 
 import scala.collection.mutable
 import org.elasticmq.NeverReceived
-import org.elasticmq.actor.queue.InternalMessage.PreciseDateTime
 import org.elasticmq.actor.queue.ReceiveRequestAttemptCache.ReceiveFailure.Invalid
 import org.elasticmq.actor.test.MutableNowProvider
 import org.scalatest.{FunSuite, Matchers}
@@ -23,7 +22,8 @@ class ReceiveRequestAttemptCacheTest extends FunSuite with Matchers {
       1L,
       "content",
       Map.empty,
-      PreciseDateTime(),
+      nowProvider.now,
+      orderIndex = 0,
       NeverReceived,
       receiveCount = 0,
       isFifo = false,
@@ -70,7 +70,8 @@ class ReceiveRequestAttemptCacheTest extends FunSuite with Matchers {
       1L,
       "content",
       Map.empty,
-      PreciseDateTime(),
+      nowProvider.now,
+      orderIndex = 0,
       NeverReceived,
       receiveCount = 0,
       isFifo = false,

--- a/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
@@ -1,8 +1,8 @@
 package org.elasticmq.actor.queue
 
 import scala.collection.mutable
-
 import org.elasticmq.NeverReceived
+import org.elasticmq.actor.queue.InternalMessage.PreciseDateTime
 import org.elasticmq.actor.queue.ReceiveRequestAttemptCache.ReceiveFailure.Invalid
 import org.elasticmq.actor.test.MutableNowProvider
 import org.joda.time.DateTime
@@ -24,7 +24,7 @@ class ReceiveRequestAttemptCacheTest extends FunSuite with Matchers {
       1L,
       "content",
       Map.empty,
-      DateTime.now(),
+      PreciseDateTime(),
       NeverReceived,
       receiveCount = 0,
       isFifo = false,
@@ -71,7 +71,7 @@ class ReceiveRequestAttemptCacheTest extends FunSuite with Matchers {
       1L,
       "content",
       Map.empty,
-      DateTime.now(),
+      PreciseDateTime(),
       NeverReceived,
       receiveCount = 0,
       isFifo = false,

--- a/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/queue/ReceiveRequestAttemptCacheTest.scala
@@ -5,7 +5,6 @@ import org.elasticmq.NeverReceived
 import org.elasticmq.actor.queue.InternalMessage.PreciseDateTime
 import org.elasticmq.actor.queue.ReceiveRequestAttemptCache.ReceiveFailure.Invalid
 import org.elasticmq.actor.test.MutableNowProvider
-import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
 
 class ReceiveRequestAttemptCacheTest extends FunSuite with Matchers {

--- a/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
+++ b/core/src/test/scala/org/elasticmq/actor/test/DataCreationHelpers.scala
@@ -62,7 +62,8 @@ trait DataCreationHelpers {
       messageAttributes,
       nextDelivery,
       messageGroupId,
-      messageDeduplicationId
+      messageDeduplicationId,
+      orderIndex = 0
     )
 
   def createNewMessageData(messageData: MessageData) =
@@ -72,6 +73,7 @@ trait DataCreationHelpers {
       messageData.messageAttributes,
       messageData.nextDelivery,
       messageData.messageGroupId,
-      messageData.messageDeduplicationId
+      messageData.messageDeduplicationId,
+      orderIndex = 0
     )
 }

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -692,6 +692,32 @@ class AmazonJavaSdkTestSuite extends FunSuite with Matchers with BeforeAndAfter 
     allMessages.map(_.getBody) should be(messageBodies)
   }
 
+  test("FIFO queues should deliver messages in the same order as they are sent in a batch") {
+    // Given
+    val queueUrl = createFifoQueue()
+
+    // When
+    val maxValidNumberOfMessagesInABatch = 10
+    val messages = for (i <- 1 to maxValidNumberOfMessagesInABatch) yield {
+      new SendMessageBatchRequestEntry()
+        .withId(s"Id$i")
+        .withMessageBody(s"Body$i")
+        .withMessageDeduplicationId(s"DeduplicationId$i")
+        .withMessageGroupId("messageGroupId")
+    }
+
+    client.sendMessageBatch(new SendMessageBatchRequest(queueUrl, messages.asJava))
+
+    // Then
+    val receivedMessages =
+      client
+        .receiveMessage(new ReceiveMessageRequest(queueUrl).withMaxNumberOfMessages(maxValidNumberOfMessagesInABatch))
+        .getMessages
+        .asScala
+
+    receivedMessages.map(_.getBody) should contain theSameElementsInOrderAs messages.map(_.getMessageBody)
+  }
+
   test("FIFO queues should deliver the same messages for the same request attempt id") {
     // Given
     val queueUrl = createFifoQueue()

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityBatchDirectives.scala
@@ -9,7 +9,7 @@ trait ChangeMessageVisibilityBatchDirectives {
     p.action("ChangeMessageVisibilityBatch") {
       queueActorFromRequest(p) { queueActor =>
         val resultsFuture =
-          batchRequest("ChangeMessageVisibilityBatchRequestEntry", p) { (messageData, id) =>
+          batchRequest("ChangeMessageVisibilityBatchRequestEntry", p) { (messageData, id, _) =>
             doChangeMessageVisibility(queueActor, messageData).map { _ =>
               <ChangeMessageVisibilityBatchResultEntry>
               <Id>{id}</Id>

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/DeleteMessageBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/DeleteMessageBatchDirectives.scala
@@ -11,7 +11,7 @@ trait DeleteMessageBatchDirectives {
   def deleteMessageBatch(p: AnyParams) = {
     p.action("DeleteMessageBatch") {
       queueActorFromRequest(p) { queueActor =>
-        val resultsFuture = batchRequest("DeleteMessageBatchRequestEntry", p) { (messageData, id) =>
+        val resultsFuture = batchRequest("DeleteMessageBatchRequestEntry", p) { (messageData, id, _) =>
           val receiptHandle = messageData(ReceiptHandleParameter)
           val result = queueActor ? DeleteMessage(DeliveryReceipt(receiptHandle))
 


### PR DESCRIPTION
Internal messages are created with a creation-timestamp truncated to milliseconds (see [DateTime](https://github.com/JodaOrg/joda-time/blob/5f98d636174cc0c6b76c9f434ee17e2b36577414/src/main/java/org/joda/time/DateTime.java#L36)) and are compared with each other using this timestamp. Since the implementation of the FIFO queue uses a internally a `PriorityQueue` for queuing and this `PriorityQueue` does not guarantee the order of queued messages for messages with the same order (see [PriorityQueue](https://www.scala-lang.org/api/2.13.0/scala/collection/mutable/PriorityQueue.html)) it may happen that messages received in a batch may not be ordered corresponding to their order in the batch. 

Since the AWS SQS guarantees that messages within a single batch are enqueued in the order they are sent (see [SendMessageBatchRequest](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/AmazonSQS.html#sendMessageBatch-com.amazonaws.services.sqs.model.SendMessageBatchRequest-)) this PR attempts to mirror this guarantee in ElasticMQ by providing a more precised creation-timestamp called `PreciseDateTime` which relays upon the already used `DateTime` and an additional nano seconds precision.

Relates to #267.
