### PR TITLE
Make messageAttributeDigest optional

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageBatchDirectives.scala
@@ -23,7 +23,11 @@ trait SendMessageBatchDirectives {
             case (message, digest, messageAttributeDigest) =>
               <SendMessageBatchResultEntry>
                 <Id>{id}</Id>
-                <MD5OfMessageAttributes>{messageAttributeDigest}</MD5OfMessageAttributes>
+                {
+                  if (!messageAttributeDigest.isEmpty) <MD5OfMessageAttributes>{
+                    messageAttributeDigest
+                  }</MD5OfMessageAttributes>
+                }
                 <MD5OfMessageBody>{digest}</MD5OfMessageBody>
                 <MessageId>{message.id.id}</MessageId>
               </SendMessageBatchResultEntry>

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -32,7 +32,11 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
             respondWith {
               <SendMessageResponse>
                 <SendMessageResult>
-                  <MD5OfMessageAttributes>{messageAttributeDigest}</MD5OfMessageAttributes>
+                  {
+                    if (!messageAttributeDigest.isEmpty) <MD5OfMessageAttributes>{
+                      messageAttributeDigest
+                    }</MD5OfMessageAttributes>
+                  }
                   <MD5OfMessageBody>{digest}</MD5OfMessageBody>
                   <MessageId>{message.id.id}</MessageId>
                 </SendMessageResult>
@@ -170,7 +174,11 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
       message: NewMessageData
   ): Future[(MessageData, String, String)] = {
     val digest = md5Digest(message.content)
-    val messageAttributeDigest = md5AttributeDigest(message.messageAttributes)
+    val messageAttributeDigest = if (message.messageAttributes.isEmpty) {
+      ""
+    } else {
+      md5AttributeDigest(message.messageAttributes)
+    }
 
     for {
       message <- queueActor ? SendMessage(message)


### PR DESCRIPTION
There is currently an issue when using the PHP SDK, which expects a message to have message attributes if a value for MD5OfMessageAttributes is provided.