### PR TITLE
Set the default accountId to 12 digits of 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ queues {
 // Region and accountId which will be included in resource ids
 aws {
     region = us-west-2
-    accountId = 000000000
+    accountId = 000000000000
 }
 ````
 

--- a/server/src/main/resources/reference.conf
+++ b/server/src/main/resources/reference.conf
@@ -48,5 +48,5 @@ queues {
 
 aws {
     region = "elasticmq"
-    accountId = "000000000"
+    accountId = "000000000000"
 }


### PR DESCRIPTION
Thanks to https://github.com/softwaremill/elasticmq/pull/290 , we can now set accountId and region by `.conf`.

But default accuntId is set 9 digits of 0, compatibility has been lost.
So I changed default accountId to 12 digits of 0.