### PR TITLE
Handle tags when creating a queue

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
@@ -16,7 +16,7 @@ import scala.async.Async._
 import scala.concurrent.Future
 
 trait CreateQueueDirectives {
-  this: ElasticMQDirectives with QueueURLModule with AttributesModule with SQSLimitsModule =>
+  this: ElasticMQDirectives with QueueURLModule with AttributesModule with TagsModule with SQSLimitsModule =>
 
   def createQueue(p: AnyParams) = {
     p.action("CreateQueue") {
@@ -77,7 +77,8 @@ trait CreateQueueDirectives {
               now,
               redrivePolicy.map(rd => DeadLettersQueueData(rd.queueName, rd.maxReceiveCount)),
               isFifo,
-              hasContentBasedDeduplication
+              hasContentBasedDeduplication,
+              tags = tagNameAndValuesReader.read(p)
             )
 
             if (!queueName.matches("[\\p{Alnum}\\._-]*")) {


### PR DESCRIPTION
Hello,

I found that when we create a queue via the rest api the tags are not processed.
I tried the fix using localstack and it seems to react as expected.
I couldn't find any test on this part of the code (but I am a newby in Scala / Akka), please help me if you want me to add some (even if it's a really small fix).

Thank you for the tool :)