### PR TITLE
relax visibility of several queue actor methods to ease customisation

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -40,7 +40,7 @@ class QueueManagerActor(nowProvider: NowProvider) extends ReplyingActor with Log
     case ListQueues() => queues.keySet.toSeq
   }
 
-  private def createQueueActor(nowProvider: NowProvider, queueData: QueueData): ActorRef = {
+  protected def createQueueActor(nowProvider: NowProvider, queueData: QueueData): ActorRef = {
     val deadLetterQueueActor = queueData.deadLettersQueue.flatMap { qd => queues.get(qd.name) }
     val copyMessagesToQueueActor = queueData.copyMessagesTo.flatMap { queueName => queues.get(queueName) }
     val moveMessagesToQueueActor = queueData.moveMessagesTo.flatMap { queueName => queues.get(queueName) }


### PR DESCRIPTION
This PR is driven from a project where there was a need to provide a slightly customised Actor system, but which proved to be quite difficult due to strict visibility of methods in `Actor` and `QueueManagerActor` and thus resulted in quite a lot of copy-paste code.

Relaxing visibility of some methods in the above mentioned classes should allow for a better customisation support for those who wish to inherit from base implementation.