### PR TITLE
Keeping original SentTimestamp and ApproximateFirstReceiveTimestamp

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -22,6 +22,7 @@ trait QueueActorMessageOps extends Logging {
         receiveMessages(visibilityTimeout, count, receiveRequestAttemptId)
       case DeleteMessage(deliveryReceipt) => deleteMessage(deliveryReceipt)
       case LookupMessage(messageId)       => messageQueue.byId.get(messageId.id).map(_.toMessageData)
+      case MoveMessageToDLQ(message)      => moveToDeadLetterQueue(message)
     }
 
   private def handleOrRedirectMessage(message: NewMessageData): ReplyAction[MessageData] = {
@@ -123,7 +124,7 @@ trait QueueActorMessageOps extends Logging {
           case default => Some(default)
         }
       })
-      .getOrElse(getMessagesFromQueue(visibilityTimeout, count))
+      .getOrElse(getMessagesFromQueue(count))
       .map { internalMessage =>
         // Putting the msg again into the queue, with a new next delivery
         val newNextDelivery = computeNextDelivery(visibilityTimeout)
@@ -150,12 +151,12 @@ trait QueueActorMessageOps extends Logging {
     }
   }
 
-  private def getMessagesFromQueue(visibilityTimeout: VisibilityTimeout, count: Int) = {
+  private def getMessagesFromQueue(count: Int) = {
     val deliveryTime = nowProvider.nowMillis
     messageQueue.dequeue(count, deliveryTime).flatMap { internalMessage =>
       if (queueData.deadLettersQueue.map(_.maxReceiveCount).exists(_ <= internalMessage.receiveCount)) {
         logger.debug(s"${queueData.name}: send message $internalMessage to dead letters actor $deadLettersActorRef")
-        deadLettersActorRef.foreach(_ ! SendMessage(internalMessage.toNewMessageData))
+        deadLettersActorRef.foreach(_ ! MoveMessageToDLQ(internalMessage))
         internalMessage.deliveryReceipts.foreach(dr => deleteMessage(DeliveryReceipt(dr)))
         None
       } else {
@@ -183,6 +184,29 @@ trait QueueActorMessageOps extends Logging {
         // Just removing the msg from the map. The msg will be removed from the queue when trying to receive it.
         messageQueue.remove(msgId)
       }
+    }
+  }
+
+  private def moveToDeadLetterQueue(message: InternalMessage): Unit = {
+    def moveMessageToDLQ(internalMessage: InternalMessage): Unit = {
+      messageQueue += internalMessage
+      logger.debug(s"Moved message with id ${internalMessage.id} to DLQ ${queueData.name}")
+    }
+
+    copyMessagesToActorRef.foreach { _ ! SendMessage(message.toNewMessageData) }
+
+    if (queueData.isFifo) {
+      // Ensure a message with the same deduplication id is not on the queue already. If the message is already on the
+      // queue do nothing.
+      // TODO: A message dedup id should be checked up to 5 mins after it has been received. If it has been deleted
+      // during that period, it should _still_ be used when deduplicating new messages. If there's a match with a
+      // deleted message (that was sent less than 5 minutes ago, the new message should not be added).
+      messageQueue.byId.values.find(isDuplicate(message.toNewMessageData, _)) match {
+        case Some(_) => ()
+        case None    => moveMessageToDLQ(message)
+      }
+    } else {
+      moveMessageToDLQ(message)
     }
   }
 }

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -26,7 +26,7 @@ case class GetQueueStatistics(deliveryTime: Long) extends QueueQueueMsg[QueueSta
 case class ClearQueue() extends QueueQueueMsg[Unit]
 
 case class SendMessage(message: NewMessageData) extends QueueMessageMsg[MessageData]
-case class MoveMessageToDLQ(message: InternalMessage) extends QueueMessageMsg[Unit]
+case class MoveMessage(message: InternalMessage) extends QueueMessageMsg[Unit]
 case class UpdateVisibilityTimeout(messageId: MessageId, visibilityTimeout: VisibilityTimeout)
     extends QueueMessageMsg[Either[MessageDoesNotExist, Unit]]
 case class ReceiveMessages(

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -2,6 +2,7 @@ package org.elasticmq.msg
 
 import akka.actor.ActorRef
 import org.elasticmq._
+import org.elasticmq.actor.queue.InternalMessage
 import org.elasticmq.actor.reply.Replyable
 import org.joda.time.Duration
 
@@ -25,6 +26,7 @@ case class GetQueueStatistics(deliveryTime: Long) extends QueueQueueMsg[QueueSta
 case class ClearQueue() extends QueueQueueMsg[Unit]
 
 case class SendMessage(message: NewMessageData) extends QueueMessageMsg[MessageData]
+case class MoveMessageToDLQ(message: InternalMessage) extends QueueMessageMsg[Unit]
 case class UpdateVisibilityTimeout(messageId: MessageId, visibilityTimeout: VisibilityTimeout)
     extends QueueMessageMsg[Either[MessageDoesNotExist, Unit]]
 case class ReceiveMessages(


### PR DESCRIPTION
Fixes #386.

In real SQS, when message is moved to DLQ the SentTimestamp and ApproximateFirstReceiveTimestamp are not preserved.
In ElasticMQ, both of attributes were initialised to new values. Once we were moving message to DLQ, we were treating it as completely new message, thus we were initialising attributes to default values.

Fix assumes, that message that is being sent to DLQ is not a new message. We are treating it as already existing one with filled values that should be copied to DLQ. 