### PR TITLE
Validate empty string attributes

### DIFF
--- a/core/src/main/scala/org/elasticmq/Limits.scala
+++ b/core/src/main/scala/org/elasticmq/Limits.scala
@@ -72,8 +72,8 @@ object Limits {
     )
 
   def verifyMessageStringAttribute(
-      attributeValue: String,
       attributeName: String,
+      attributeValue: String,
       limits: Limits
   ): Either[String, Unit] =
     for {

--- a/core/src/test/scala/org/elasticmq/LimitsTest.scala
+++ b/core/src/test/scala/org/elasticmq/LimitsTest.scala
@@ -59,16 +59,18 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
   "Validation of message string attribute in strict mode" should {
     "pass if string attribute contains only allowed characters" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, StrictSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute(testString, "attribute1", StrictSQSLimits) shouldBe Right(())
     }
 
     "pass if the string is empty" in {
-      Limits.verifyMessageStringAttribute("", StrictSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("", "attribute1", StrictSQSLimits) shouldBe Left(
+        "Attribute 'attribute1' must contain a non-empty value of type 'String'"
+      )
     }
 
     "fail if string contains any not allowed character" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x19, 0x10efff).map(_.toChar).mkString
-      val error = Limits.verifyMessageStringAttribute(testString, StrictSQSLimits).left.value
+      val error = Limits.verifyMessageStringAttribute(testString, "attribute1", StrictSQSLimits).left.value
       error shouldBe "InvalidMessageContents"
     }
   }
@@ -76,47 +78,62 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
   "Validation of message string attribute in relaxed mode" should {
     "pass if string attribute contains only allowed characters" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute(testString, "attribute1", RelaxedSQSLimits) shouldBe Right(())
     }
 
     "pass if the string is empty" in {
-      Limits.verifyMessageStringAttribute("", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("", "attribute1", RelaxedSQSLimits) shouldBe Right(())
     }
 
     "pass if string contains any not allowed character" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x19, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute(testString, "attribute1", RelaxedSQSLimits) shouldBe Right(())
     }
   }
 
   "Validation of message number attribute in strict mode" should {
     "pass if the number is between the limits (-10^128 - 10^126)" in {
-      Limits.verifyMessageNumberAttribute(BigDecimal(10).pow(126).toString(), StrictSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute((-BigDecimal(10).pow(128)).toString(), StrictSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute(BigDecimal(0).toString(), StrictSQSLimits) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(
+        BigDecimal(10).pow(126).toString(),
+        "numAttribute",
+        StrictSQSLimits
+      ) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(
+        (-BigDecimal(10).pow(128)).toString(),
+        "numAttribute",
+        StrictSQSLimits
+      ) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(BigDecimal(0).toString(), "numAttribute", StrictSQSLimits) shouldBe Right(())
       Limits.verifyMessageNumberAttribute(
         BigDecimal(Random.nextDouble()).toString(),
+        "numAttribute",
         StrictSQSLimits
       ) shouldBe Right(
         ()
       )
     }
 
+    "fail if the number is an empty string" in {
+      val emptyStringNumber = ""
+      val error = Limits.verifyMessageNumberAttribute(emptyStringNumber, "numAttribute", StrictSQSLimits)
+      error shouldBe Left("Attribute 'numAttribute' must contain a non-empty value of type 'Number'")
+    }
+
     "fail if the number is bigger than the upper bound" in {
       val overUpperBound = BigDecimal(10, MathContext.UNLIMITED).pow(126) + BigDecimal(0.1)
-      val error = Limits.verifyMessageNumberAttribute(overUpperBound.toString, StrictSQSLimits)
+      val error = Limits.verifyMessageNumberAttribute(overUpperBound.toString, "numAttribute", StrictSQSLimits)
       error shouldBe Left(s"Number attribute value $overUpperBound should be in range (-10**128..10**126)")
     }
 
     "fail if the number is below the lower bound" in {
       val belowLowerBound = -BigDecimal(10, MathContext.UNLIMITED).pow(128) - BigDecimal(0.1)
       val error =
-        Limits.verifyMessageNumberAttribute(belowLowerBound.toString, StrictSQSLimits)
+        Limits.verifyMessageNumberAttribute(belowLowerBound.toString, "numAttribute", StrictSQSLimits)
       error shouldBe Left(s"Number attribute value $belowLowerBound should be in range (-10**128..10**126)")
     }
 
     "fail if the number can't be parsed" in {
-      val error = Limits.verifyMessageNumberAttribute("12312312a", StrictSQSLimits).left.value
+      val error = Limits.verifyMessageNumberAttribute("12312312a", "numAttribute", StrictSQSLimits).left.value
       error shouldBe s"Number attribute value 12312312a should be in range (-10**128..10**126)"
     }
   }
@@ -125,11 +142,19 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
     "always pass the validation" in {
       val belowLowerBound = -BigDecimal(10).pow(128) - BigDecimal(0.1)
       val overUpperBound = BigDecimal(10).pow(126) + BigDecimal(0.1)
-      Limits.verifyMessageNumberAttribute(belowLowerBound.toString, RelaxedSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute(BigDecimal(10).pow(126).toString(), RelaxedSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute((-BigDecimal(10).pow(128)).toString(), RelaxedSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute(overUpperBound.toString, RelaxedSQSLimits) shouldBe Right(())
-      Limits.verifyMessageNumberAttribute("12312312a", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(belowLowerBound.toString, "numAttribute", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(
+        BigDecimal(10).pow(126).toString(),
+        "numAttribute",
+        RelaxedSQSLimits
+      ) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(
+        (-BigDecimal(10).pow(128)).toString(),
+        "numAttribute",
+        RelaxedSQSLimits
+      ) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute(overUpperBound.toString, "numAttribute", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageNumberAttribute("12312312a", "numAttribute", RelaxedSQSLimits) shouldBe Right(())
     }
   }
 

--- a/core/src/test/scala/org/elasticmq/LimitsTest.scala
+++ b/core/src/test/scala/org/elasticmq/LimitsTest.scala
@@ -59,18 +59,18 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
   "Validation of message string attribute in strict mode" should {
     "pass if string attribute contains only allowed characters" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, "attribute1", StrictSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("attribute1", testString, StrictSQSLimits) shouldBe Right(())
     }
 
     "fail if the string is empty" in {
-      Limits.verifyMessageStringAttribute("", "attribute1", StrictSQSLimits) shouldBe Left(
+      Limits.verifyMessageStringAttribute("attribute1", "", StrictSQSLimits) shouldBe Left(
         "Attribute 'attribute1' must contain a non-empty value of type 'String'"
       )
     }
 
     "fail if string contains any not allowed character" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x19, 0x10efff).map(_.toChar).mkString
-      val error = Limits.verifyMessageStringAttribute(testString, "attribute1", StrictSQSLimits).left.value
+      val error = Limits.verifyMessageStringAttribute("attribute1", testString, StrictSQSLimits).left.value
       error shouldBe "InvalidMessageContents"
     }
   }
@@ -78,16 +78,16 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
   "Validation of message string attribute in relaxed mode" should {
     "pass if string attribute contains only allowed characters" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, "attribute1", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("attribute1", testString, RelaxedSQSLimits) shouldBe Right(())
     }
 
     "pass if the string is empty" in {
-      Limits.verifyMessageStringAttribute("", "attribute1", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("attribute1", "", RelaxedSQSLimits) shouldBe Right(())
     }
 
     "pass if string contains any not allowed character" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x19, 0x10efff).map(_.toChar).mkString
-      Limits.verifyMessageStringAttribute(testString, "attribute1", RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageStringAttribute("attribute1", testString, RelaxedSQSLimits) shouldBe Right(())
     }
   }
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -1390,6 +1390,14 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
     result.isLeft should be(true)
   }
 
+  test("should return an error if strict & message body is empty") {
+    strictOnlyShouldThrowException { cli =>
+      val queueUrl = cli.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
+
+      cli.sendMessage(new SendMessageRequest(queueUrl, ""))
+    }
+  }
+
   test("should return an error if strict & sending an invalid character") {
     strictOnlyShouldThrowException { cli =>
       // Given

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
@@ -1,6 +1,6 @@
 package org.elasticmq.rest.sqs
 
-import com.amazonaws.services.sqs.model.{AmazonSQSException, CreateQueueRequest, MessageAttributeValue, ReceiveMessageRequest, SendMessageBatchRequest, SendMessageBatchRequestEntry, SendMessageRequest}
+import com.amazonaws.services.sqs.model._
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
@@ -1,0 +1,81 @@
+package org.elasticmq.rest.sqs
+
+import com.amazonaws.services.sqs.model.{AmazonSQSException, CreateQueueRequest, MessageAttributeValue, ReceiveMessageRequest, SendMessageBatchRequest, SendMessageBatchRequestEntry, SendMessageRequest}
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
+
+class MessageAttributesTests extends SqsClientServerCommunication with Matchers with OptionValues {
+
+  test("Sending message with empty attribute value and String data type should result in error") {
+    val queueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
+
+    val ex = the[AmazonSQSException] thrownBy client.sendMessage(
+      new SendMessageRequest(queueUrl, "Message 1")
+        .addMessageAttributesEntry("attribute1", new MessageAttributeValue().withStringValue("").withDataType("String"))
+    )
+
+    ex.getMessage should include("Attribute 'attribute1' must contain a non-empty value of type 'String")
+  }
+
+  test("Sending message with empty attribute value and Number data type should result in error") {
+    val queueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
+
+    val ex = the[AmazonSQSException] thrownBy client.sendMessage(
+      new SendMessageRequest(queueUrl, "Message 1")
+        .addMessageAttributesEntry("attribute1", new MessageAttributeValue().withStringValue("").withDataType("Number"))
+    )
+
+    ex.getMessage should include("Attribute 'attribute1' must contain a non-empty value of type 'Number")
+  }
+
+  test("Sending message with empty attribute type should result in error") {
+    val queueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
+
+    val ex = the[AmazonSQSException] thrownBy client.sendMessage(
+      new SendMessageRequest(queueUrl, "Message 1")
+        .addMessageAttributesEntry("attribute1", new MessageAttributeValue().withStringValue("value").withDataType(""))
+    )
+
+    ex.getMessage should include("Attribute 'attribute1' must contain a non-empty attribute type")
+  }
+
+  test(
+    "Sending message in batch should result in accepting only those messages that do not have empty message attributes"
+  ) {
+    val queueUrl = client.createQueue(new CreateQueueRequest("testQueue1")).getQueueUrl
+
+    val resp = client.sendMessageBatch(
+      new SendMessageBatchRequest(queueUrl).withEntries(
+        new SendMessageBatchRequestEntry("1", "Message 1").withMessageAttributes(
+          Map(
+            "attribute1" -> new MessageAttributeValue().withStringValue("value1").withDataType("String")
+          ).asJava
+        ),
+        new SendMessageBatchRequestEntry("2", "Message 2").withMessageAttributes(
+          Map(
+            "attribute1" -> new MessageAttributeValue().withStringValue("").withDataType("String")
+          ).asJava
+        ),
+        new SendMessageBatchRequestEntry("3", "Message 3").withMessageAttributes(
+          Map(
+            "attribute1" -> new MessageAttributeValue().withStringValue("value1").withDataType("String")
+          ).asJava
+        )
+      )
+    )
+
+    resp.getSuccessful should have size 2
+
+    val receiveMessageResponse =
+      client.receiveMessage(new ReceiveMessageRequest().withQueueUrl(queueUrl).withMaxNumberOfMessages(3))
+    receiveMessageResponse.getMessages.asScala should have size 2
+    receiveMessageResponse.getMessages.asScala
+      .map(message => message.getBody)
+      .foreach(messageBody => {
+        messageBody should (be("Message 1") or be("Message 3"))
+      })
+  }
+
+}

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/MessageAttributesTests.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.sqs.model._
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 
-import scala.jdk.CollectionConverters.{ListHasAsScala, MapHasAsJava}
+import scala.collection.JavaConverters.{collectionAsScalaIterableConverter, mapAsJavaMapConverter}
 
 class MessageAttributesTests extends SqsClientServerCommunication with Matchers with OptionValues {
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -84,18 +84,20 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
           val strValue =
             parameters("MessageAttribute." + i + ".Value.StringValue")
           Limits
-            .verifyMessageStringAttribute(strValue, sqsLimits)
+            .verifyMessageStringAttribute(strValue, name, sqsLimits)
             .fold(error => throw new SQSException(error), identity)
           StringMessageAttribute(strValue, customDataType)
         case "Number" =>
           val strValue =
             parameters("MessageAttribute." + i + ".Value.StringValue")
           Limits
-            .verifyMessageNumberAttribute(strValue, sqsLimits)
+            .verifyMessageNumberAttribute(strValue, name, sqsLimits)
             .fold(error => throw new SQSException(error), identity)
           NumberMessageAttribute(strValue, customDataType)
         case "Binary" =>
           BinaryMessageAttribute.fromBase64(parameters("MessageAttribute." + i + ".Value.BinaryValue"), customDataType)
+        case "" =>
+          throw new SQSException(s"Attribute '$name' must contain a non-empty attribute type")
         case _ =>
           throw new Exception("Currently only handles String, Number and Binary typed attributes")
       }
@@ -124,7 +126,7 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
     val messageAttributes = getMessageAttributes(parameters)
     val messageSystemAttributes = getMessageSystemAttributes(parameters)
 
-    Limits.verifyMessageStringAttribute(body, sqsLimits).fold(error => throw new SQSException(error), identity)
+    Limits.verifyMessageBody(body, sqsLimits).fold(error => throw new SQSException(error), identity)
 
     val messageGroupId = parameters.get(MessageGroupIdParameter) match {
       // MessageGroupId is only supported for FIFO queues

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -84,7 +84,7 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
           val strValue =
             parameters("MessageAttribute." + i + ".Value.StringValue")
           Limits
-            .verifyMessageStringAttribute(strValue, name, sqsLimits)
+            .verifyMessageStringAttribute(name, strValue, sqsLimits)
             .fold(error => throw new SQSException(error), identity)
           StringMessageAttribute(strValue, customDataType)
         case "Number" =>


### PR DESCRIPTION
Fixes #373 

According to doc, message attribute value/data type can't be an empty String. Same applies to message body