### PR TITLE
Loading custom config files in elasticmq native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,7 +251,7 @@ lazy val nativeServer: Project = (project in file("native-server"))
       (baseDirectory.value / ".." / "server" / "docker" / "elasticmq.conf") -> "/opt/docker/elasticmq.conf",
       ((target in GraalVMNativeImage).value / "elasticmq-native-server") -> "/opt/docker/bin/elasticmq-native-server"
     ),
-    dockerEntrypoint := Seq("/sbin/tini", "--", "/opt/docker/bin/elasticmq-native-server", "-Dconfig.file=/opt/docker/elasticmq.conf"),
+    dockerEntrypoint := Seq("/sbin/tini", "--", "/opt/docker/bin/elasticmq-native-server", "-Dconfig.file=/opt/elasticmq.conf"),
     dockerUpdateLatest := true,
     dockerExposedPorts := Seq(9324),
     dockerCommands := {
@@ -262,8 +262,9 @@ lazy val nativeServer: Project = (project in file("native-server"))
         case _ => false
       }
       val (front, back) = commands.splitAt(index + 1)
+      val copyConfig = ExecCmd("COPY", "/opt/docker/elasticmq.conf", "/opt/elasticmq.conf")
       val tiniCommand = ExecCmd("RUN", "apk", "add", "--no-cache", "tini")
-      front ++ Seq(tiniCommand) ++ back
+      front ++ Seq(tiniCommand, copyConfig) ++ back
     },
     packageName in Docker := "elasticmq-native",
     dockerUsername := Some("softwaremill"),

--- a/native-server/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/native-server/src/main/resources/META-INF/native-image/reflect-config.json
@@ -104,6 +104,11 @@
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },
 {
+  "name": "akka.event.DefaultLoggingFilter",
+  "allDeclaredConstructors": true,
+  "allPublicConstructors": true
+},
+{
   "name":"akka.event.EventStreamUnsubscriber",
   "allDeclaredConstructors":true
 },
@@ -113,6 +118,16 @@
 },
 {
   "name":"akka.event.LoggerMessageQueueSemantics"
+},
+{
+  "name": "akka.event.Logging$DefaultLogger",
+  "allDeclaredConstructors": true,
+  "allPublicConstructors": true
+},
+{
+  "name": "akka.event.Logging$StdOutLogger",
+  "allDeclaredConstructors": true,
+  "allPublicConstructors": true
 },
 {
   "name":"akka.event.slf4j.Slf4jLogger",
@@ -450,5 +465,8 @@
 {
   "name":"sun.security.x509.SubjectKeyIdentifierExtension",
   "methods":[{"name":"<init>","parameterTypes":["java.lang.Boolean","java.lang.Object"] }]
+},
+{
+  "name":"[B"
 }
 ]


### PR DESCRIPTION
Fixes #368 

With those changes it is possible to start the docker with mounted custom config via command `docker run --rm -it --publish 9324:9324 -v /path/to/elasticmq.conf:/opt/elasticmq.conf softwaremill/elasticmq-native`. Before, the path was `/opt/docker/elasticmq.conf` which was not compliant with standard elasticmq image.

I have also added few classes to `reflect-config.json` as the application was failing with `NoClassDefFoundError`