### PR TITLE
Addition of UI to fat jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -170,6 +170,8 @@ lazy val server: Project = (project in file("server"))
   .settings(Seq(
     name := "elasticmq-server",
     libraryDependencies ++= Seq(logback, config),
+    unmanagedResourceDirectories in Compile += { baseDirectory.value / ".." / "ui" / "build" },
+    assembly := assembly.dependsOn(yarnTask.toTask(" build")).value,
     mainClass in assembly := Some("org.elasticmq.server.Main"),
     coverageMinimum := 52,
     // s3 upload
@@ -216,7 +218,7 @@ lazy val server: Project = (project in file("server"))
       javaOptions in Universal ++= Seq("-Dconfig.file=/opt/elasticmq.conf"),
       mappings in Docker ++= Seq(
         (baseDirectory.value / "docker" / "elasticmq.conf") -> "/opt/elasticmq.conf"
-      ) ++ sbt.Path.directory(baseDirectory.value / ".." / "ui" / "build"),
+      ),
       publishLocal in Docker := (publishLocal in Docker).dependsOn(yarnTask.toTask(" build")).value,
       dockerCommands += Cmd(
         "COPY",
@@ -224,16 +226,10 @@ lazy val server: Project = (project in file("server"))
         s"--chown=${(daemonUser in Docker).value}:root",
         "/opt/elasticmq.conf",
         "/opt"
-      ),
-      dockerCommands += Cmd(
-        "COPY",
-        "/build/",
-        "/opt/webapp"
       )
     )
   )
   .dependsOn(core, restSqs, commonTest % "test")
-  .aggregate(ui)
 
 val graalVmVersion = "20.2.0"
 
@@ -293,7 +289,7 @@ lazy val nativeServer: Project = (project in file("native-server"))
       val copyUI = Cmd(
         "COPY",
         "/build/",
-        "/opt/webapp"
+        "/opt/docker"
       )
       val tiniCommand = ExecCmd("RUN", "apk", "add", "--no-cache", "tini")
       front ++ Seq(tiniCommand, copyConfig, copyUI) ++ back

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/stats/StatisticsDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/stats/StatisticsDirectives.scala
@@ -44,7 +44,7 @@ trait StatisticsDirectives extends StatisticsJsonFormat {
   case object ResourceBased extends UILocation
   case object FileBased extends UILocation
 
-  val uiLocation: UILocation =
+  lazy val uiLocation: UILocation =
     if (new File("index.html").exists) FileBased
     else if (Try(Source.fromResource("index.html")).toOption.isDefined) ResourceBased
     else throw new RuntimeException("Could not find UI files")


### PR DESCRIPTION
Addition of UI to fat jar.

Besides that, I have unified the paths to UI in `SeatisticDirectives`.
Right now, Fat Jar and normal docker image takes UI from resources, while native docker image via file system.