### PR TITLE
ReceiveMessage should accept MessageAttributeName apart from MessageAttributeName.N

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -20,7 +20,7 @@ trait ReceiveMessageDirectives {
     val MaxNumberOfMessagesAttribute = "MaxNumberOfMessages"
     val WaitTimeSecondsAttribute = "WaitTimeSeconds"
     val ReceiveRequestAttemptIdAttribute = "ReceiveRequestAttemptId"
-    val MessageAttributeNamePattern = "MessageAttributeName\\.\\d".r
+    val MessageAttributeNamePattern = "MessageAttributeName(\\.\\d)?".r
     val MessageDeduplicationIdAttribute = "MessageDeduplicationId"
     val MessageGroupIdAttribute = "MessageGroupId"
     val AWSTraceHeaderAttribute = "AWSTraceHeader"


### PR DESCRIPTION
MessageAttributeName (without .N) works on AWS via REST API although it's not used in Java SDK.
It may be related to #418