### PR TITLE
Add sequence number to FIFO queue

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/queue/InternalMessage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/InternalMessage.scala
@@ -83,8 +83,7 @@ case class InternalMessage(
 }
 
 object InternalMessage {
-  def from(newMessageData: NewMessageData, queueData: QueueData, sequenceNumber: BigInt): InternalMessage = {
-    val attributes = updateSequenceNumberAttribute(newMessageData, queueData, sequenceNumber)
+  def from(newMessageData: NewMessageData, queueData: QueueData): InternalMessage = {
 
     val now = System.currentTimeMillis()
     new InternalMessage(
@@ -92,7 +91,7 @@ object InternalMessage {
       mutable.Buffer.empty,
       newMessageData.nextDelivery.toMillis(now, queueData.delay.getMillis).millis,
       newMessageData.content,
-      attributes,
+      newMessageData.messageAttributes,
       new DateTime(),
       newMessageData.orderIndex,
       NeverReceived,
@@ -105,16 +104,4 @@ object InternalMessage {
   }
 
   private def generateId() = MessageId(UUID.randomUUID().toString)
-
-  private def updateSequenceNumberAttribute(
-      newMessageData: NewMessageData,
-      queueData: QueueData,
-      sequenceNumber: BigInt
-  ) = {
-    if (!queueData.isFifo) {
-      (newMessageData.messageAttributes - "SequenceNumber")
-    } else {
-      newMessageData.messageAttributes.updated("SequenceNumber", StringMessageAttribute(sequenceNumber.toString()))
-    }
-  }
 }

--- a/core/src/main/scala/org/elasticmq/actor/queue/InternalMessage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/InternalMessage.scala
@@ -84,11 +84,11 @@ case class InternalMessage(
 
 object InternalMessage {
 
-  def from(newMessageData: NewMessageData, queueData: QueueData, n: BigInt): InternalMessage = {
+  def from(newMessageData: NewMessageData, queueData: QueueData, sequenceNumber: BigInt): InternalMessage = {
     val attributes = newMessageData
       .messageAttributes
       .updatedWith("SequenceNumber")(
-      _ => if (queueData.isFifo) Some(StringMessageAttribute(n.toString())) else None
+      _ => if (queueData.isFifo) Some(StringMessageAttribute(sequenceNumber.toString())) else None
     )
 
     val now = System.currentTimeMillis()

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -13,8 +13,15 @@ trait QueueActorStorage {
   def copyMessagesToActorRef: Option[ActorRef]
   def moveMessagesToActorRef: Option[ActorRef]
 
+  def nextSequenceNumber(): BigInt = {
+    val x = sequenceNumber
+    sequenceNumber = sequenceNumber + 1
+    x
+  }
+
   var queueData: QueueData = initialQueueData
   var messageQueue: MessageQueue = MessageQueue(queueData.isFifo)
   var fifoMessagesHistory: FifoDeduplicationIdsHistory = FifoDeduplicationIdsHistory.newHistory()
   val receiveRequestAttemptCache = new ReceiveRequestAttemptCache
+  var sequenceNumber = BigInt(0)
 }

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -13,7 +13,7 @@ trait QueueActorStorage {
   def copyMessagesToActorRef: Option[ActorRef]
   def moveMessagesToActorRef: Option[ActorRef]
 
-  def nextSequenceNumber(): BigInt = {
+  def nextSequenceNumber(): Long = {
     val next = sequenceNumber
     sequenceNumber = sequenceNumber + 1
     next
@@ -23,5 +23,5 @@ trait QueueActorStorage {
   var messageQueue: MessageQueue = MessageQueue(queueData.isFifo)
   var fifoMessagesHistory: FifoDeduplicationIdsHistory = FifoDeduplicationIdsHistory.newHistory()
   val receiveRequestAttemptCache = new ReceiveRequestAttemptCache
-  var sequenceNumber = BigInt(0)
+  private var sequenceNumber: Long = 0
 }

--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorStorage.scala
@@ -14,9 +14,9 @@ trait QueueActorStorage {
   def moveMessagesToActorRef: Option[ActorRef]
 
   def nextSequenceNumber(): BigInt = {
-    val x = sequenceNumber
+    val next = sequenceNumber
     sequenceNumber = sequenceNumber + 1
-    x
+    next
   }
 
   var queueData: QueueData = initialQueueData

--- a/core/src/main/scala/org/elasticmq/actor/queue/operations/SendMessageOp.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/operations/SendMessageOp.scala
@@ -37,7 +37,7 @@ trait SendMessageOp extends Logging {
   }
 
   private def addMessage(message: NewMessageData) = {
-    val internalMessage = InternalMessage.from(message, queueData)
+    val internalMessage = InternalMessage.from(message, queueData, nextSequenceNumber())
     messageQueue += internalMessage
     fifoMessagesHistory = fifoMessagesHistory.addNew(internalMessage)
     logger.debug(s"${queueData.name}: Sent message with id ${internalMessage.id}")

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -861,7 +861,7 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
     val firstSeqNum = client.sendMessage(new SendMessageRequest(queueUrl, "Body 1").withMessageGroupId(groupId)).getSequenceNumber
     val secondSeqNum = client.sendMessage(new SendMessageRequest(queueUrl, "Body 2").withMessageGroupId(groupId)).getSequenceNumber
 
-    BigInt(firstSeqNum) should be <  BigInt(secondSeqNum)
+    firstSeqNum.toLong should be <  secondSeqNum.toLong
   }
 
   test("FIFO queue - SequenceNumber continues to increase after deleting message from queue") {
@@ -875,7 +875,7 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
 
     val secondSeqNum = client.sendMessage(new SendMessageRequest(queueUrl, "Body 2").withMessageGroupId(groupId1)).getSequenceNumber
 
-    BigInt(seqNumFromDeleted) should be < BigInt(secondSeqNum)
+    seqNumFromDeleted.toLong should be < secondSeqNum.toLong
   }
 
   test("FIFO queue - SequenceNumber is not incremented between receives") {
@@ -890,23 +890,6 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
 
     res.getSequenceNumber should equal(seqNum1)
     res.getSequenceNumber should equal(seqNum2)
-  }
-
-  test("FIFO queue - SequenceNumber attribute between two groups can be the same") {
-    val groupId1 = "1"
-    val groupId2 = "2"
-    val queueUrl = createFifoQueue()
-
-    val seqNum11 = client.sendMessage(new SendMessageRequest(queueUrl, "Body 1").withMessageGroupId(groupId1)).getSequenceNumber
-    val seqNum12 = client.sendMessage(new SendMessageRequest(queueUrl, "Body 3").withMessageGroupId(groupId1)).getSequenceNumber
-
-    val seqNum21 = client.sendMessage(new SendMessageRequest(queueUrl, "Body 2").withMessageGroupId(groupId2)).getSequenceNumber
-    val seqNum22 = client.sendMessage(new SendMessageRequest(queueUrl, "Body 4").withMessageGroupId(groupId2)).getSequenceNumber
-
-    groupId1 shouldNot equal(groupId2)
-
-    BigInt(seqNum11) should be < BigInt(seqNum12)
-    BigInt(seqNum21) should be < BigInt(seqNum22)
   }
 
   def queueVisibilityTimeout(queueUrl: String): Long = getQueueLongAttribute(queueUrl, visibilityTimeoutAttribute)

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -24,11 +24,11 @@ trait ReceiveMessageDirectives {
     val MessageDeduplicationIdAttribute = "MessageDeduplicationId"
     val MessageGroupIdAttribute = "MessageGroupId"
     val AWSTraceHeaderAttribute = "AWSTraceHeader"
-    val SequenceNumber = "SequenceNumber"
+    val SequenceNumberAttribute = "SequenceNumber"
 
     val AllAttributeNames = SentTimestampAttribute :: ApproximateReceiveCountAttribute ::
       ApproximateFirstReceiveTimestampAttribute :: SenderIdAttribute :: MessageDeduplicationIdAttribute ::
-      MessageGroupIdAttribute :: AWSTraceHeaderAttribute :: SequenceNumber :: Nil
+      MessageGroupIdAttribute :: AWSTraceHeaderAttribute :: SequenceNumberAttribute :: Nil
   }
 
   def receiveMessage(p: AnyParams) = {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ReceiveMessageDirectives.scala
@@ -24,10 +24,11 @@ trait ReceiveMessageDirectives {
     val MessageDeduplicationIdAttribute = "MessageDeduplicationId"
     val MessageGroupIdAttribute = "MessageGroupId"
     val AWSTraceHeaderAttribute = "AWSTraceHeader"
+    val SequenceNumber = "SequenceNumber"
 
     val AllAttributeNames = SentTimestampAttribute :: ApproximateReceiveCountAttribute ::
       ApproximateFirstReceiveTimestampAttribute :: SenderIdAttribute :: MessageDeduplicationIdAttribute ::
-      MessageGroupIdAttribute :: AWSTraceHeaderAttribute :: Nil
+      MessageGroupIdAttribute :: AWSTraceHeaderAttribute :: SequenceNumber :: Nil
   }
 
   def receiveMessage(p: AnyParams) = {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -35,6 +35,12 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
                   {messageAttributeDigest.map(d => <MD5OfMessageAttributes>{d}</MD5OfMessageAttributes>).getOrElse(())}
                   <MD5OfMessageBody>{digest}</MD5OfMessageBody>
                   <MessageId>{message.id.id}</MessageId>
+                  {message.messageAttributes.get("SequenceNumber").flatMap(sn => {
+                    sn match {
+                      case StringMessageAttribute(x, _) => Some(<SequenceNumber>{x}</SequenceNumber>)
+                      case _ => None
+                    }
+                }).getOrElse(())}
                 </SendMessageResult>
                 <ResponseMetadata>
                   <RequestId>{EmptyRequestId}</RequestId>


### PR DESCRIPTION
According to [Message docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_Message.html), there should be additional attribute in `ReceiveMessage` - `SequenceNumber`. Other than that `SequenceNumber` should be returned in `SendMessage` result as per [this doc](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_SendMessage.html).

Number should be increasing per GroupId.

Few things I've noticed on AWS:
- SequenceNumber is increasing globally, but in docs it is specified that it should increase at least per GroupId.
- SequenceNumber passed as an attribute in endMessage is ignored when receiving the same message

Connected with issue #522 