### PR TITLE
Introduced limit for message attributes

### DIFF
--- a/core/src/test/scala/org/elasticmq/LimitsTest.scala
+++ b/core/src/test/scala/org/elasticmq/LimitsTest.scala
@@ -56,6 +56,22 @@ class LimitsTest extends AnyWordSpec with Matchers with EitherValues {
     }
   }
 
+  "Validate number of message attributes" should {
+    val attributesLimit = 10
+
+    "fail on exceeded sqs limit in strict mode" in {
+      Limits.verifyMessageAttributesNumber(attributesLimit, StrictSQSLimits) shouldBe Right(())
+      Limits.verifyMessageAttributesNumber(attributesLimit + 1, StrictSQSLimits) shouldBe Left(
+        "Number of message attributes [11] exceeds the allowed maximum [10]."
+      )
+    }
+
+    "pass on exceeded sqs limit in relaxed mode" in {
+      Limits.verifyMessageAttributesNumber(attributesLimit, RelaxedSQSLimits) shouldBe Right(())
+      Limits.verifyMessageAttributesNumber(attributesLimit + 1, RelaxedSQSLimits) shouldBe Right(())
+    }
+  }
+
   "Validation of message string attribute in strict mode" should {
     "pass if string attribute contains only allowed characters" in {
       val testString = List(0x9, 0xa, 0xd, 0x21, 0xe005, 0x10efff).map(_.toChar).mkString

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -889,6 +889,24 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
     res.getSequenceNumber should equal(seqNum2)
   }
 
+  test("sendMessage should throw when message has more than 10 message attributes") {
+    val sqsMessageAttributesLimit = 10
+
+    val queueUrl = client.createQueue(new CreateQueueRequest("q")).getQueueUrl
+    val attr = new MessageAttributeValue().withStringValue("str").withDataType("String")
+    val atLeastElevenMessageAttributes = (1 to 11).map(_.toString -> attr)
+      .toMap
+      .asJava
+
+    atLeastElevenMessageAttributes.size() > sqsMessageAttributesLimit shouldBe true
+
+    assertThrows[AmazonSQSException] {
+      client.sendMessage(
+        new SendMessageRequest(queueUrl, "MessageWithMoreThan10MessageAttributes")
+          .withMessageAttributes(atLeastElevenMessageAttributes))
+    }
+  }
+
   def queueVisibilityTimeout(queueUrl: String): Long = getQueueLongAttribute(queueUrl, visibilityTimeoutAttribute)
 
   test("should receive no more than the given amount of messages") {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -71,6 +71,9 @@ trait SendMessageDirectives { this: ElasticMQDirectives with SQSLimitsModule =>
       .union(List(0))
       .max // even if nothing, return 0
 
+    Limits.verifyMessageAttributesNumber(numAttributes, sqsLimits)
+      .fold(error => throw new SQSException(error), identity)
+
     (1 to numAttributes).map { i =>
       val name = parameters("MessageAttribute." + i + ".Name")
       val dataType = parameters("MessageAttribute." + i + ".Value.DataType")


### PR DESCRIPTION
Connected with [issue 320](https://github.com/softwaremill/elasticmq/issues/320)

Now sending message with more than 10 message attributes is unsuccessful.