### PR TITLE
CI refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,12 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  ci:
+  ci-2-12:
     # run on external PRs, but not on internal PRs since those will be run by push to branch
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      matrix:
-        scala: [2.12.15, 2.13.7]
     runs-on: ubuntu-18.04
+    env:
+      scala: 2.12.15
     steps:
     - name: Check-out repository
       id: repo-checkout
@@ -30,8 +29,40 @@ jobs:
           ~/.sbt
           ~/.ivy2/cache
           ~/.coursier
-        key: ${{ runner.os }}-sbt-${{ matrix.scala }}-${{ hashFiles('**/build.sbt') }}
+        key: ${{ runner.os }}-sbt-${{ env.scala }}-${{ hashFiles('**/build.sbt') }}
 
     - name: Run tests
       id: run-tests
-      run: sbt ++${{ matrix.scala }} test
+      run: sbt ++${{ env.scala }} test
+
+  ci-2-13:
+    # run on external PRs, but not on internal PRs since those will be run by push to branch
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-18.04
+    env:
+      scala: 2.13.7
+    steps:
+      - name: Check-out repository
+        id: repo-checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        id: jdk-setup
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'zulu'
+
+      - name: Cache SBT
+        id: cache-sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier
+          key: ${{ runner.os }}-sbt-${{ env.scala }}-${{ hashFiles('**/build.sbt') }}
+
+      - name: Run tests
+        id: run-tests
+        run: sbt ++${{ env.scala }} test

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -32,3 +32,13 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+  - name: automatic merge for scala-steward pull requests affecting .scalafmt.conf
+      conditions:
+        - author=scala-steward
+        - check-success=ci-2-12
+        - check-success=ci-2-13
+        - "#files=1"
+        - files=.scalafmt.conf
+      actions:
+        merge:
+          method: merge

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,8 +6,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting build.sbt
     conditions:
       - author=scala-steward
-      - check-success=ci (2.12.12)
-      - check-success=ci (2.13.4)
+      - check-success=ci-2-12
+      - check-success=ci-2-13
       - "#files=1"
       - files=build.sbt
     actions:
@@ -16,8 +16,8 @@ pull_request_rules:
   - name: automatic merge for scala-steward pull requests affecting project plugins.sbt
     conditions:
       - author=scala-steward
-      - check-success=ci (2.12.12)
-      - check-success=ci (2.13.4)
+      - check-success=ci-2-12
+      - check-success=ci-2-13
       - "#files=1"
       - files=project/plugins.sbt
     actions:
@@ -26,8 +26,8 @@ pull_request_rules:
   - name: semi-automatic merge for scala-steward pull requests
     conditions:
       - author=scala-steward
-      - check-success=ci (2.12.12)
-      - check-success=ci (2.13.4)
+      - check-success=ci-2-12
+      - check-success=ci-2-13
       - "#approved-reviews-by>=1"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -33,12 +33,12 @@ pull_request_rules:
       merge:
         method: merge
   - name: automatic merge for scala-steward pull requests affecting .scalafmt.conf
-      conditions:
-        - author=scala-steward
-        - check-success=ci-2-12
-        - check-success=ci-2-13
-        - "#files=1"
-        - files=.scalafmt.conf
-      actions:
-        merge:
-          method: merge
+    conditions:
+      - author=scala-steward
+      - check-success=ci-2-12
+      - check-success=ci-2-13
+      - "#files=1"
+      - files=.scalafmt.conf
+    actions:
+      merge:
+        method: merge

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ import scoverage.ScoverageKeys._
 
 import scala.sys.process.Process
 
-val v2_12 = "2.12.14"
-val v2_13 = "2.13.6"
+val v2_12 = "2.12.15"
+val v2_13 = "2.13.7"
 
 lazy val uiDirectory = settingKey[File]("Path to the ui project directory")
 lazy val updateYarn = taskKey[Unit]("Update yarn")


### PR DESCRIPTION
Firstly number versions of Scala in `build.sbt` were not in line with CI's versions.
Additionally `mergify` was using hardcoded names of jobs with old versions.
I removed `matrix` from workflow definition and split it to two separate jobs.
When updating Scala versions in `build.sbt` we should remember to update one in GH actions too.