### PR TITLE
Fix ChangeMessageVisibilityBatchRequest to return a BatchResultErrorEntry in case of invalid receipt handles rather than failing the request.

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
+++ b/core/src/main/scala/org/elasticmq/actor/queue/QueueActorMessageOps.scala
@@ -27,8 +27,8 @@ trait QueueActorMessageOps
     msg match {
       case SendMessage(message) =>
         handleOrRedirectMessage(message, context).send()
-      case UpdateVisibilityTimeout(messageId, visibilityTimeout) =>
-        updateVisibilityTimeout(messageId, visibilityTimeout).send()
+      case UpdateVisibilityTimeout(deliveryReceipt, visibilityTimeout) =>
+        updateVisibilityTimeout(deliveryReceipt, visibilityTimeout).send()
       case ReceiveMessages(visibilityTimeout, count, _, receiveRequestAttemptId) =>
         receiveMessages(visibilityTimeout, count, receiveRequestAttemptId).send()
       case DeleteMessage(deliveryReceipt) =>

--- a/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueMsg.scala
@@ -41,8 +41,8 @@ case class ClearQueue() extends QueueQueueMsg[Unit]
 
 case class SendMessage(message: NewMessageData) extends QueueMessageMsg[MessageData]
 case class MoveMessage(message: InternalMessage, moveDestination: MoveDestination) extends QueueMessageMsg[Unit]
-case class UpdateVisibilityTimeout(messageId: MessageId, visibilityTimeout: VisibilityTimeout)
-    extends QueueMessageMsg[Either[MessageDoesNotExist, Unit]]
+case class UpdateVisibilityTimeout(deliveryReceipt: DeliveryReceipt, visibilityTimeout: VisibilityTimeout)
+    extends QueueMessageMsg[Either[InvalidReceiptHandle, Unit]]
 case class ReceiveMessages(
     visibilityTimeout: VisibilityTimeout,
     count: Int,

--- a/core/src/test/scala/org/elasticmq/actor/QueueEventListenerTest.scala
+++ b/core/src/test/scala/org/elasticmq/actor/QueueEventListenerTest.scala
@@ -53,8 +53,9 @@ class QueueEventListenerTest extends ActorTest with QueueManagerWithListenerForE
   test("QueueMessageUpdated event should be triggerred") {
     for {
       Right(queue) <- queueManagerActor ? CreateQueue(createQueueData("q1", MillisVisibilityTimeout(1L)))
-      msg <- queue ? SendMessage(createNewMessageData("abc", "xyz", Map.empty, MillisNextDelivery(100)))
-      _ <- queue ? UpdateVisibilityTimeout(msg.id, MillisVisibilityTimeout(2000))
+      _ <- queue ? SendMessage(createNewMessageData("abc", "xyz", Map.empty, MillisNextDelivery(100)))
+      List(msg) <- queue ? ReceiveMessages(MillisVisibilityTimeout(1), 1, None, None)
+      _ <- queue ? UpdateVisibilityTimeout(msg.deliveryReceipt.get, MillisVisibilityTimeout(2000))
     } yield {
       queueEventListener.expectMsgType[QueueEvent.QueueCreated].queue.name shouldBe "q1"
       queueEventListener.expectMsgType[QueueEvent.MessageAdded].message.id shouldBe "abc"

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityBatchDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityBatchDirectives.scala
@@ -1,20 +1,34 @@
 package org.elasticmq.rest.sqs
 
 import Constants._
+import org.elasticmq.{DeliveryReceipt, MillisVisibilityTimeout}
+import org.elasticmq.msg.UpdateVisibilityTimeout
+import org.elasticmq.actor.reply._
 import org.elasticmq.rest.sqs.Action.ChangeMessageVisibilityBatch
 import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
 
 trait ChangeMessageVisibilityBatchDirectives {
-  this: ElasticMQDirectives with ChangeMessageVisibilityDirectives with BatchRequestsModule =>
+  this: ElasticMQDirectives with BatchRequestsModule =>
   def changeMessageVisibilityBatch(p: AnyParams) = {
     p.action(ChangeMessageVisibilityBatch) {
       queueActorFromRequest(p) { queueActor =>
         val resultsFuture =
           batchRequest("ChangeMessageVisibilityBatchRequestEntry", p) { (messageData, id, _) =>
-            doChangeMessageVisibility(queueActor, messageData).map { _ =>
-              <ChangeMessageVisibilityBatchResultEntry>
-              <Id>{id}</Id>
-            </ChangeMessageVisibilityBatchResultEntry>
+            val receiptHandle = messageData(ReceiptHandleParameter)
+            val visibilityTimeout = MillisVisibilityTimeout.fromSeconds(messageData(VisibilityTimeoutParameter).toLong)
+            val result = queueActor ? UpdateVisibilityTimeout(DeliveryReceipt(receiptHandle), visibilityTimeout)
+
+            result.map {
+              case Left(error) =>
+                <BatchResultErrorEntry>
+                  <Id>{id}</Id>
+                  <Code>{error.code}</Code>
+                  <Message>{error.message}</Message>
+                </BatchResultErrorEntry>
+              case Right(_) =>
+                <ChangeMessageVisibilityBatchResultEntry>
+                  <Id>{id}</Id>
+                </ChangeMessageVisibilityBatchResultEntry>
             }
           }
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ChangeMessageVisibilityDirectives.scala
@@ -1,40 +1,34 @@
 package org.elasticmq.rest.sqs
 
-import Constants._
-import org.elasticmq.{DeliveryReceipt, MillisVisibilityTimeout}
-import akka.actor.ActorRef
 import org.elasticmq.actor.reply._
 import org.elasticmq.msg.UpdateVisibilityTimeout
 import org.elasticmq.rest.sqs.Action.ChangeMessageVisibility
+import org.elasticmq.rest.sqs.Constants._
 import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
+import org.elasticmq.{DeliveryReceipt, MillisVisibilityTimeout}
 
 trait ChangeMessageVisibilityDirectives { this: ElasticMQDirectives =>
   def changeMessageVisibility(p: AnyParams) = {
     p.action(ChangeMessageVisibility) {
       queueActorFromRequest(p) { queueActor =>
-        doChangeMessageVisibility(queueActor, p).map { _ =>
-          respondWith {
-            <ChangeMessageVisibilityResponse>
-              <ResponseMetadata>
-                <RequestId>{EmptyRequestId}</RequestId>
-              </ResponseMetadata>
-            </ChangeMessageVisibilityResponse>
-          }
+        (p.requiredParam(ReceiptHandleParameter) and p.requiredParam(VisibilityTimeoutParameter)) {
+          (receipt, visibilityTimeout) =>
+            val result = queueActor ? UpdateVisibilityTimeout(
+              DeliveryReceipt(receipt),
+              MillisVisibilityTimeout.fromSeconds(visibilityTimeout.toLong)
+            )
+            result.map {
+              case Left(error) => throw new SQSException(error.code, errorMessage = Some(error.message))
+              case Right(_) =>
+                respondWith {
+                  <ChangeMessageVisibilityResponse>
+                  <ResponseMetadata>
+                    <RequestId>{EmptyRequestId}</RequestId>
+                  </ResponseMetadata>
+                </ChangeMessageVisibilityResponse>
+                }
+            }
         }
-      }
-    }
-  }
-
-  def doChangeMessageVisibility(queueActor: ActorRef, parameters: AnyParams) = {
-    val visibilityTimeout = MillisVisibilityTimeout.fromSeconds(parameters(VisibilityTimeoutParameter).toLong)
-    val msgId = DeliveryReceipt(parameters(ReceiptHandleParameter)).extractId
-
-    for {
-      updateResult <- queueActor ? UpdateVisibilityTimeout(msgId, visibilityTimeout)
-    } yield {
-      updateResult match {
-        case Left(_)  => throw SQSException.invalidParameterValue
-        case Right(_) => // ok
       }
     }
   }


### PR DESCRIPTION
Fix `ChangeMessageVisibilityBatchRequest` to return a `BatchResultErrorEntry` in case of invalid receipt handles rather than failing the request.

It looks like changes to message visibility used to be done internally using message ids rather than receipt handles. 
Though, similarly to #324, the most recent (valid) receipt handle has to be used to be consistent with the SQS API. Therefore this changes `UpdateVisibilityTimeout` to contain a `DeliveryReceipt` rather than a `MessageId`.

(fixes #632) 