### PR TITLE
Cleanup around queue name validation

### DIFF
--- a/core/src/main/scala/org/elasticmq/ElasticMQError.scala
+++ b/core/src/main/scala/org/elasticmq/ElasticMQError.scala
@@ -16,6 +16,11 @@ case class QueueCreationError(queueName: String, reason: String) extends Elastic
   val message = s"Queue named $queueName could not be created because of $reason"
 }
 
+case class InvalidParameterValue(queueName: String, reason: String) extends ElasticMQError {
+  val code = "InvalidParameterValue"
+  val message = reason
+}
+
 class MessageDoesNotExist(val queueName: String, messageId: MessageId) extends ElasticMQError {
   val code = "MessageDoesNotExist"
   val message = s"Message does not exist: $messageId in queue: $queueName"

--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -27,7 +27,7 @@ class QueueManagerActor(nowProvider: NowProvider, limits: Limits, queueEventList
           logger.info(s"Creating queue $queueData")
           Limits.verifyQueueName(queueData.name, queueData.isFifo, limits) match {
             case Left(error) =>
-              Left(QueueCreationError(queueData.name, error))
+              Left(InvalidParameterValue(queueData.name, error))
             case Right(_) =>
               val actor = createQueueActor(nowProvider, queueData, queueEventListener)
               queues(queueData.name) = actor

--- a/persistence/persistence-file/src/main/scala/org/elasticmq/persistence/file/QueuePersister.scala
+++ b/persistence/persistence-file/src/main/scala/org/elasticmq/persistence/file/QueuePersister.scala
@@ -31,7 +31,7 @@ object QueuePersister {
     s"queues {\n$queuesMetadata}"
   }
 
-  private def quote(name: String): String = s"\"$name\"";
+  private def quote(name: String): String = s""""$name""""
 
   private def serializeQueueMetadata(queueNameToMetadata: (String, QueueMetadata)): String = {
     val options = ConfigRenderOptions.defaults().setOriginComments(false).setJson(false).setFormatted(false)

--- a/persistence/persistence-file/src/main/scala/org/elasticmq/persistence/file/QueuePersister.scala
+++ b/persistence/persistence-file/src/main/scala/org/elasticmq/persistence/file/QueuePersister.scala
@@ -25,20 +25,13 @@ object QueuePersister {
 
   def prepareQueuesConfig(queues: List[QueueData]): String = {
     val queuesMetadata: String = queues
-      .map(queue => (toPersistQueueName(queue.name), toQueueConfig(queue)))
+      .map(queue => (quote(queue.name), toQueueConfig(queue)))
       .map(serializeQueueMetadata)
       .mkString("")
     s"queues {\n$queuesMetadata}"
   }
 
-  private val fifoQueueNamePattern = "^(.*)\\.fifo$".r
-
-  private def toPersistQueueName(queueName: String): String = {
-    queueName match {
-      case fifoQueueNamePattern(prefix) => prefix
-      case name                         => name
-    }
-  }
+  private def quote(name: String): String = s"\"$name\"";
 
   private def serializeQueueMetadata(queueNameToMetadata: (String, QueueMetadata)): String = {
     val options = ConfigRenderOptions.defaults().setOriginComments(false).setJson(false).setFormatted(false)

--- a/persistence/persistence-file/src/test/scala/org/elasticmq/persistence/file/QueuePersisterTest.scala
+++ b/persistence/persistence-file/src/test/scala/org/elasticmq/persistence/file/QueuePersisterTest.scala
@@ -21,7 +21,7 @@ class QueuePersisterTest extends AnyFunSuite with Matchers {
 
     actual shouldBe
       """queues {
-        | queue1 {contentBasedDeduplication=false,copyTo="",defaultVisibilityTimeout=10,delay=0,fifo=false,moveTo="",receiveMessageWait=10,tags{}}
+        | "queue1" {contentBasedDeduplication=false,copyTo="",defaultVisibilityTimeout=10,delay=0,fifo=false,moveTo="",receiveMessageWait=10,tags{}}
         |}""".stripMargin
   }
 
@@ -41,7 +41,7 @@ class QueuePersisterTest extends AnyFunSuite with Matchers {
 
     actual shouldBe
       """queues {
-        | queue2 {contentBasedDeduplication=false,copyTo="",defaultVisibilityTimeout=10,delay=0,fifo=true,moveTo="",receiveMessageWait=10,tags{}}
+        | "queue2.fifo" {contentBasedDeduplication=false,copyTo="",defaultVisibilityTimeout=10,delay=0,fifo=true,moveTo="",receiveMessageWait=10,tags{}}
         |}""".stripMargin
   }
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -522,14 +522,14 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
 
   test("FIFO queues should respond quickly during long polling") {
     // Given
-    val deadLetterQueue = new CreateQueueRequest(s"dead.testFifoQueue-long-poll.fifo")
+    val deadLetterQueue = new CreateQueueRequest(s"dead-testFifoQueue-long-poll.fifo")
       .addAttributesEntry("FifoQueue", "true")
       .addAttributesEntry("ContentBasedDeduplication", "false")
 
     val deadLetterUrl = client.createQueue(deadLetterQueue).getQueueUrl
 
     val redrivePolicy =
-      RedrivePolicy("dead.testFifoQueue-long-poll.fifo", awsRegion, awsAccountId, 1).toJson.toString()
+      RedrivePolicy("dead-testFifoQueue-long-poll.fifo", awsRegion, awsAccountId, 1).toJson.toString()
 
     val fifoQueue = new CreateQueueRequest(s"testFifoQueue-long-poll.fifo")
       .addAttributesEntry("FifoQueue", "true")

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/CreateQueueDirectives.scala
@@ -129,8 +129,8 @@ trait CreateQueueDirectives {
           val createResult =
             await(queueManagerActor ? CreateQueueMsg(newQueueData))
           createResult match {
-            case Left(e) =>
-              throw new SQSException("Concurrent access: " + e.message)
+            case Left(e: ElasticMQError) =>
+              throw new SQSException(e.code, errorMessage = Some(e.message))
             case Right(_) => newQueueData
           }
         case Some(queueActor) =>


### PR DESCRIPTION
* implement proper queue name validation
* implement proper error handling when above fails
* restore previous queue persistence name handling and surround with quotes as suggested in #125