### PR TITLE
Add missing actions RemovePermission and ListDeadLetterSourceQueues

### DIFF
--- a/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
+++ b/core/src/main/scala/org/elasticmq/actor/QueueManagerActor.scala
@@ -58,6 +58,11 @@ class QueueManagerActor(nowProvider: NowProvider, limits: Limits, queueEventList
         result
 
       case ListQueues() => queues.keySet.toSeq
+
+      case ListDeadLetterSourceQueues(queueName) =>
+        queues.collect {
+          case (name, actor) if actor.queueData.deadLettersQueue.exists(_.name == queueName) => name
+        }.toList
     }
 
   protected def createQueueActor(

--- a/core/src/main/scala/org/elasticmq/msg/QueueManagerMsg.scala
+++ b/core/src/main/scala/org/elasticmq/msg/QueueManagerMsg.scala
@@ -10,3 +10,4 @@ case class CreateQueue(request: CreateQueueData) extends QueueManagerMsg[Either[
 case class DeleteQueue(queueName: String) extends QueueManagerMsg[Unit]
 case class LookupQueue(queueName: String) extends QueueManagerMsg[Option[ActorRef]]
 case class ListQueues() extends QueueManagerMsg[Seq[String]]
+case class ListDeadLetterSourceQueues(queueName: String) extends QueueManagerMsg[List[String]]

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonCliTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonCliTestSuite.scala
@@ -294,7 +294,7 @@ class AmazonCliTestSuite
       s"""${version.executable} sqs add-permission --label l --aws-account-ids=$awsAccountId --actions=get --endpoint=$ServiceEndpoint --region=us-west-1 --no-sign-request --queue-url=$url""" !!
     }
 
-    test(s"should remove permission ${version.name}") {
+    test(s"should remove permission ${version.name}", Only213) {
       // given
       val url = createQueue("permission-test").QueueUrl
       s"""${version.executable} sqs add-permission --label l --aws-account-ids=$awsAccountId --actions=get --endpoint=$ServiceEndpoint --region=us-west-1 --no-sign-request --queue-url=$url""" !
@@ -522,7 +522,7 @@ class AmazonCliTestSuite
       result.parseJson.convertTo[GetQueueAttributesResponse].Attributes.get("VisibilityTimeout") shouldBe Some("99")
     }
 
-    test(s"should get source queues of a dlq with ${version.name}") {
+    test(s"should get source queues of a dlq with ${version.name}", Only213) {
       // given
       val dlq = createQueue("testDlq")
       val redrivePolicy = RedrivePolicy("testDlq", awsRegion, awsAccountId, 1).toJson.toString.replaceAll("\"", "\\\\\"")

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonCliTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonCliTestSuite.scala
@@ -291,6 +291,15 @@ class AmazonCliTestSuite
       s"""${version.executable} sqs add-permission --label l --aws-account-ids=$awsAccountId --actions=get --endpoint=$ServiceEndpoint --region=us-west-1 --no-sign-request --queue-url=$url""" !!
     }
 
+    test(s"should remove permission ${version.name}") {
+      // given
+      val url = createQueue("permission-test").QueueUrl
+      s"""${version.executable} sqs add-permission --label l --aws-account-ids=$awsAccountId --actions=get --endpoint=$ServiceEndpoint --region=us-west-1 --no-sign-request --queue-url=$url""" !
+
+      // when ~> then
+      s"""${version.executable} sqs remove-permission --label l --endpoint=$ServiceEndpoint --region=us-west-1 --no-sign-request --queue-url=$url""" !!
+    }
+
     test(s"should purge queue ${version.name}") {
       // given
       val url = createQueue("permission-test").QueueUrl

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/Action.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/Action.scala
@@ -15,6 +15,7 @@ object Action extends Enumeration {
   val GetQueueAttributes = Value("GetQueueAttributes")
   val SetQueueAttributes = Value("SetQueueAttributes")
   val ReceiveMessage = Value("ReceiveMessage")
+  val RemovePermission = Value("RemovePermission")
   val SendMessageBatch = Value("SendMessageBatch")
   val SendMessage = Value("SendMessage")
   val TagQueue = Value("TagQueue")

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/Action.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/Action.scala
@@ -9,6 +9,7 @@ object Action extends Enumeration {
   val DeleteMessage = Value("DeleteMessage")
   val DeleteQueue = Value("DeleteQueue")
   val GetQueueUrl = Value("GetQueueUrl")
+  val ListDeadLetterSourceQueues = Value("ListDeadLetterSourceQueues")
   val ListQueueTags = Value("ListQueueTags")
   val ListQueues = Value("ListQueues")
   val PurgeQueue = Value("PurgeQueue")

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ListDeadLetterSourceQueuesDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/ListDeadLetterSourceQueuesDirectives.scala
@@ -1,0 +1,69 @@
+package org.elasticmq.rest.sqs
+
+import org.elasticmq.actor.reply._
+import org.elasticmq.msg.ListDeadLetterSourceQueues
+import org.elasticmq.rest.sqs.Action.{ListDeadLetterSourceQueues => ListDeadLetterSourceQueuesAction}
+import org.elasticmq.rest.sqs.Constants._
+import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
+import org.elasticmq.rest.sqs.model.RequestPayload
+import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
+
+import scala.xml.Elem
+
+trait ListDeadLetterSourceQueuesDirectives { this: ElasticMQDirectives with QueueURLModule with ResponseMarshaller =>
+  def listDeadLetterSourceQueues(p: RequestPayload)(implicit marshallerDependencies: MarshallerDependencies) = {
+    p.action(ListDeadLetterSourceQueuesAction) {
+      val payload = p.as[ListDeadLetterSourceQueuesActionRequest]
+      (getQueueNameFromQueueUrl(payload.QueueUrl) & baseQueueURL)
+        .tmap { case (deadLetterQueueName, baseURL) =>
+          for {
+            queueNames <- queueManagerActor ? ListDeadLetterSourceQueues(deadLetterQueueName)
+            queueUrls = queueNames.map(queueName => s"$baseURL/$queueName")
+          } yield {
+            complete(ListDeadLetterSourceQueuesResponse(queueUrls))
+          }
+        }
+        .tapply(f => f._1)
+    }
+  }
+}
+
+case class ListDeadLetterSourceQueuesActionRequest(
+    MaxResults: Option[Int],
+    NextToken: Option[String],
+    QueueUrl: String
+)
+object ListDeadLetterSourceQueuesActionRequest {
+  implicit val requestJsonFormat: RootJsonFormat[ListDeadLetterSourceQueuesActionRequest] = jsonFormat3(ListDeadLetterSourceQueuesActionRequest.apply)
+
+  implicit val requestParamReader: FlatParamsReader[ListDeadLetterSourceQueuesActionRequest] =
+    new FlatParamsReader[ListDeadLetterSourceQueuesActionRequest] {
+      override def read(params: Map[String, String]): ListDeadLetterSourceQueuesActionRequest = {
+        new ListDeadLetterSourceQueuesActionRequest(
+          params.get(MaxResultsParameter).map(_.toInt),
+          params.get(NextTokenParameter),
+          requiredParameter(params)(QueueUrlParameter)
+        )
+      }
+    }
+}
+
+case class ListDeadLetterSourceQueuesResponse(queueUrls: List[String])
+object ListDeadLetterSourceQueuesResponse {
+  implicit val format: RootJsonFormat[ListDeadLetterSourceQueuesResponse] = jsonFormat1(ListDeadLetterSourceQueuesResponse.apply)
+
+  implicit val xmlSerializer: XmlSerializer[ListDeadLetterSourceQueuesResponse] = new XmlSerializer[ListDeadLetterSourceQueuesResponse] {
+    override def toXml(t: ListDeadLetterSourceQueuesResponse): Elem = {
+
+      <ListDeadLetterSourceQueuesResponse>
+        <ListDeadLetterSourceQueuesResult>
+          {t.queueUrls.map(queueUrl => <QueueUrl>{queueUrl}</QueueUrl>)}
+        </ListDeadLetterSourceQueuesResult>
+        <ResponseMetadata>
+          <RequestId>{EmptyRequestId}</RequestId>
+        </ResponseMetadata>
+      </ListDeadLetterSourceQueuesResponse>
+    }
+  }
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/RemovePermissionDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/RemovePermissionDirectives.scala
@@ -1,0 +1,13 @@
+package org.elasticmq.rest.sqs
+
+import org.elasticmq.rest.sqs.Action.RemovePermission
+import org.elasticmq.rest.sqs.directives.ElasticMQDirectives
+import org.elasticmq.rest.sqs.model.RequestPayload
+
+trait RemovePermissionDirectives { this: ElasticMQDirectives with QueueURLModule with ResponseMarshaller =>
+  def removePermission(p: RequestPayload)(implicit marshallerDependencies: MarshallerDependencies) = {
+    p.action(RemovePermission) {
+      emptyResponse("RemovePermissionResponse")
+    }
+  }
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -164,7 +164,8 @@ case class TheSQSRestServerBuilder(
       with TagsModule
       with UnmatchedActionRoutes
       with ResponseMarshaller
-      with QueueAttributesOps {
+      with QueueAttributesOps
+      with ListDeadLetterSourceQueuesDirectives {
 
       def serverAddress = currentServerAddress.get()
 
@@ -204,6 +205,7 @@ case class TheSQSRestServerBuilder(
         tagQueue(p) ~
         untagQueue(p) ~
         listQueueTags(p) ~
+        listDeadLetterSourceQueues(p) ~
         //4. Unmatched action
         unmatchedAction(p)
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -158,6 +158,7 @@ case class TheSQSRestServerBuilder(
       with GetQueueUrlDirectives
       with PurgeQueueDirectives
       with AddPermissionDirectives
+      with RemovePermissionDirectives
       with AttributesModule
       with TagQueueDirectives
       with TagsModule
@@ -199,6 +200,7 @@ case class TheSQSRestServerBuilder(
         getQueueAttributes(p) ~
         setQueueAttributes(p) ~
         addPermission(p) ~
+        removePermission(p) ~
         tagQueue(p) ~
         untagQueue(p) ~
         listQueueTags(p) ~

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/QueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/QueueDirectives.scala
@@ -36,7 +36,7 @@ trait QueueDirectives {
     getQueueNameFromQueueUrl(queueUrl)(queueName => queueActor(queueName, qa => queueData(qa, qd => body(qa, qd))))
   }
 
-  private def getQueueNameFromQueueUrl(queueUrl: String): Directive1[String] = {
+  protected def getQueueNameFromQueueUrl(queueUrl: String): Directive1[String] = {
 
     val matcher =
       if (contextPath.nonEmpty) {


### PR DESCRIPTION
Adds empty shell for `RemovePermission` action and fully functional (sans pagination) `ListDeadLetterSourceQueues`. Implementation of `ListDeadLetterSourceQueues` is rough because it requires loading `QueueData` for every existing queue. However I'm not aware of any better way to do this inside the elasticmq framework.

Branched off of open commit to use JSON responses, so this can be merged afterwards. Review last two commits for new changes. Tested and working locally.

Open to all feedback as this is my first contribution to the project. NBD if not wanted, mainly did this for my own exploration.

Closes #818 