### PR TITLE
fix: ignore case for x-amz-target #898

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/AnyParamDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/AnyParamDirectives.scala
@@ -22,7 +22,7 @@ trait AnyParamDirectives {
   private def extractActionFromHeader =
     extractRequest.map(request =>
       request.headers
-        .find(_.name() == "X-Amz-Target")
+        .find(_.name().equalsIgnoreCase("X-Amz-Target"))
         .flatMap(
           _.value() match {
             case actionHeaderPattern(action) => Some(action)


### PR DESCRIPTION
Fixes #898 

After updating my project dependencies, I got an "Internal Server Error" in all my elasticmq usages.

![image](https://github.com/softwaremill/elasticmq/assets/40404708/6d01e804-6212-4f9b-8e8a-85098abcce5d)

After checking the elasticmq logs, I found the "java.lang.IllegalArgumentException: Couldn't find header X-Amz-Target" error which led me to #898. This appears to be some change related to the AWS SDK SQS client. That specific issue mentions ruby client, but I can reproduce it using nodejs client.

![image](https://github.com/softwaremill/elasticmq/assets/40404708/a7f1c986-7356-4151-aae7-95f4a0965313)

Thanks @btalbot, regarding your investigation of the ticket. It allowed me to quickly build and test it, and it works perfectly.

I just pushed my own docker images for that while the PR is not merged:
```
docker pull rubnogueira/elasticmq:v1.50-rubenwithfix
docker pull rubnogueira/elasticmq-native:v1.50-rubenwithfix
```