### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ all messages could be either duplicated (using `copyTo` attribute) or redirected
 
 ### FIFO queue creation
 To create FIFO queue set value of `fifo` config parameter to `true`.
-You can add `.fifo` suffix to queue name yourself. 
+You can NOT add `.fifo` suffix to queue name yourself because the typesafe config will interpret `fifo` as a child parameter key. 
 If not then suffix will be added automatically during queue creation.
 
 # Persisting queues configuration


### PR DESCRIPTION
I was stumped for a while because my queues were not being created when I named them `queue1.fifo` in the config file.  This is because the `.` is used to delineate parameter names.

Feel free to edit this if there is a way to actually escape the `.`, but I could not find that solution.