### PR TITLE
Allow to release elasticmq for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ val buildSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
     ScmInfo(url("https://github.com/softwaremill/elasticmq"), "scm:git@github.com:softwaremill/elasticmq.git")
   ),
   scalaVersion := resolvedScalaVersion,
+  crossScalaVersions := List(v2_12, v2_13, v3),
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((3, _)) => Seq("-Xtarget:8")


### PR DESCRIPTION
My last PR introduced support for Scala 3. However after the release that included it, I noticed that version missing on [scaladex](https://index.scala-lang.org/softwaremill/elasticmq/artifacts/elasticmq-core). It seems that (according to https://github.com/sbt/sbt-ci-release#how-do-i-publish-cross-built-projects) the scala version needs to be set in `crossScalaVersions` setting in sbt, which I previously missed. Hopefully this is all that was missing, although I am not completely sure