### PR TITLE
fix: Handles MessageSystemAttributeNames

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ val scalatest = "org.scalatest" %% "scalatest" % "3.2.18"
 val awaitility = "org.awaitility" % "awaitility-scala" % "4.2.1"
 
 val amazonJavaSdkSqs = "com.amazonaws" % "aws-java-sdk-sqs" % "1.12.699" exclude ("commons-logging", "commons-logging")
-val amazonJavaV2SdkSqs = "software.amazon.awssdk" % "sqs" % "2.25.30"
+val amazonJavaV2SdkSqs = "software.amazon.awssdk" % "sqs" % "2.25.60"
 
 val pekkoVersion = "1.0.2"
 val pekkoHttpVersion = "1.0.1"

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/aws/AmazonJavaSdkNewTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/aws/AmazonJavaSdkNewTestSuite.scala
@@ -363,6 +363,29 @@ abstract class AmazonJavaSdkNewTestSuite
     result should contain theSameElementsAs Set(queue1Url, queue2Url, queue4Url)
   }
 
+  test("should receive system all attributes") {
+    // given
+    val queueUrl = testClient.createQueue(
+      "testQueue2.fifo",
+      Map(FifoQueueAttributeName -> "true", ContentBasedDeduplicationAttributeName -> "false")
+    )
+    testClient.sendMessage(
+      queueUrl,
+      "test123",
+      messageGroupId = Option("gp1"),
+      messageDeduplicationId = Option("dup1")
+    )
+
+    // when
+    val messages = testClient.receiveMessage(queueUrl, systemAttributes = List("All"))
+
+    // then
+    messages should have size 1
+    val messageAttributes = messages.head.attributes
+    messageAttributes(MessageDeduplicationId) shouldBe "dup1"
+    messageAttributes(MessageGroupId) shouldBe "gp1"
+  }
+
   private def doTestSendAndReceiveMessageWithAttributes(
       content: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV1SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV1SqsClient.scala
@@ -1,7 +1,30 @@
 package org.elasticmq.rest.sqs.client
 
 import com.amazonaws.services.sqs.AmazonSQS
-import com.amazonaws.services.sqs.model.{BatchResultErrorEntry, CancelMessageMoveTaskRequest, ChangeMessageVisibilityBatchRequest, ChangeMessageVisibilityBatchRequestEntry, CreateQueueRequest, DeleteMessageBatchRequest, DeleteMessageBatchRequestEntry, GetQueueAttributesRequest, GetQueueUrlRequest, ListDeadLetterSourceQueuesRequest, ListMessageMoveTasksRequest, MessageAttributeValue, MessageSystemAttributeValue, PurgeQueueRequest, QueueDoesNotExistException, ReceiveMessageRequest, ResourceNotFoundException, SendMessageBatchRequest, SendMessageBatchRequestEntry, SendMessageRequest, StartMessageMoveTaskRequest, UnsupportedOperationException}
+import com.amazonaws.services.sqs.model.{
+  BatchResultErrorEntry,
+  CancelMessageMoveTaskRequest,
+  ChangeMessageVisibilityBatchRequest,
+  ChangeMessageVisibilityBatchRequestEntry,
+  CreateQueueRequest,
+  DeleteMessageBatchRequest,
+  DeleteMessageBatchRequestEntry,
+  GetQueueAttributesRequest,
+  GetQueueUrlRequest,
+  ListDeadLetterSourceQueuesRequest,
+  ListMessageMoveTasksRequest,
+  MessageAttributeValue,
+  MessageSystemAttributeValue,
+  PurgeQueueRequest,
+  QueueDoesNotExistException,
+  ReceiveMessageRequest,
+  ResourceNotFoundException,
+  SendMessageBatchRequest,
+  SendMessageBatchRequestEntry,
+  SendMessageRequest,
+  StartMessageMoveTaskRequest,
+  UnsupportedOperationException
+}
 import org.elasticmq._
 
 import java.nio.ByteBuffer
@@ -49,6 +72,8 @@ class AwsSdkV1SqsClient(client: AmazonSQS) extends SqsClient {
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      messageGroupId: Option[String] = None,
+      messageDeduplicationId: Option[String] = None,
       awsTraceHeader: Option[String] = None
   ): Either[SqsClientError, Unit] = interceptErrors {
     client.sendMessage(
@@ -59,6 +84,8 @@ class AwsSdkV1SqsClient(client: AmazonSQS) extends SqsClient {
           mapAwsTraceHeader(awsTraceHeader)
         )
         .withMessageAttributes(mapMessageAttributes(messageAttributes))
+        .withMessageGroupId(messageGroupId.orNull)
+        .withMessageDeduplicationId(messageDeduplicationId.orNull)
     )
   }
 
@@ -190,7 +217,9 @@ class AwsSdkV1SqsClient(client: AmazonSQS) extends SqsClient {
 
   private def mapAwsTraceHeader(awsTraceHeader: Option[MessageMoveTaskStatus]) = {
     awsTraceHeader
-      .map(header => Map("AWSTraceHeader" -> new MessageSystemAttributeValue().withStringValue(header).withDataType("String")).asJava)
+      .map(header =>
+        Map("AWSTraceHeader" -> new MessageSystemAttributeValue().withStringValue(header).withDataType("String")).asJava
+      )
       .orNull
   }
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV1SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV1SqsClient.scala
@@ -72,9 +72,9 @@ class AwsSdkV1SqsClient(client: AmazonSQS) extends SqsClient {
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      awsTraceHeader: Option[String] = None,
       messageGroupId: Option[String] = None,
-      messageDeduplicationId: Option[String] = None,
-      awsTraceHeader: Option[String] = None
+      messageDeduplicationId: Option[String] = None
   ): Either[SqsClientError, Unit] = interceptErrors {
     client.sendMessage(
       new SendMessageRequest()

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV2SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV2SqsClient.scala
@@ -41,6 +41,8 @@ class AwsSdkV2SqsClient(client: software.amazon.awssdk.services.sqs.SqsClient) e
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      messageGroupId: Option[String] = None,
+      messageDeduplicationId: Option[String] = None,
       awsTraceHeader: Option[String] = None
   ): Either[SqsClientError, Unit] = interceptErrors {
     client.sendMessage(
@@ -50,6 +52,8 @@ class AwsSdkV2SqsClient(client: software.amazon.awssdk.services.sqs.SqsClient) e
         .messageBody(messageBody)
         .messageSystemAttributes(mapAwsTraceHeader(awsTraceHeader))
         .messageAttributes(mapMessageAttributes(messageAttributes))
+        .messageGroupId(messageGroupId.orNull)
+        .messageDeduplicationId(messageDeduplicationId.orNull)
         .build()
     )
   }
@@ -181,7 +185,7 @@ class AwsSdkV2SqsClient(client: software.amazon.awssdk.services.sqs.SqsClient) e
         ReceiveMessageRequest
           .builder()
           .queueUrl(queueUrl)
-          .attributeNamesWithStrings(systemAttributes.asJava)
+          .messageSystemAttributeNames(systemAttributes.map(SdkMessageSystemAttributeName.fromValue).asJava)
           .messageAttributeNames(messageAttributes.asJava)
           .maxNumberOfMessages(maxNumberOfMessages.map(Int.box).orNull)
           .build()

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV2SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/AwsSdkV2SqsClient.scala
@@ -41,9 +41,9 @@ class AwsSdkV2SqsClient(client: software.amazon.awssdk.services.sqs.SqsClient) e
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      awsTraceHeader: Option[String] = None,
       messageGroupId: Option[String] = None,
-      messageDeduplicationId: Option[String] = None,
-      awsTraceHeader: Option[String] = None
+      messageDeduplicationId: Option[String] = None
   ): Either[SqsClientError, Unit] = interceptErrors {
     client.sendMessage(
       SendMessageRequest

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/SqsClient.scala
@@ -18,6 +18,8 @@ trait SqsClient {
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      messageGroupId: Option[String] = None,
+      messageDeduplicationId: Option[String] = None,
       awsTraceHeader: Option[String] = None
   ): Either[SqsClientError, Unit]
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/SqsClient.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/client/SqsClient.scala
@@ -18,9 +18,9 @@ trait SqsClient {
       queueUrl: QueueUrl,
       messageBody: String,
       messageAttributes: Map[String, MessageAttribute] = Map.empty,
+      awsTraceHeader: Option[String] = None,
       messageGroupId: Option[String] = None,
-      messageDeduplicationId: Option[String] = None,
-      awsTraceHeader: Option[String] = None
+      messageDeduplicationId: Option[String] = None
   ): Either[SqsClientError, Unit]
 
   def receiveMessage(


### PR DESCRIPTION
fixes #1004 
Current implementation cannot handle recently added MessageSystemAttributeNames parameter. 