### PR TITLE
fix: FIFO queue zero delay

### DIFF
--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -135,6 +135,7 @@ trait SendMessageDirectives {
       case Some(v) if v > 0 && queueData.isFifo =>
         // FIFO queues don't support delays
         throw SQSException.invalidQueueTypeParameter(DelaySecondsParameter)
+      case Some(v) if v == 0 && queueData.isFifo => None
       case d => d
     }
 


### PR DESCRIPTION
This PR aligns fifo queue delay behavior with aws sqs when the `DelaySeconds` attribute is sent as 0 in the message
fixes: #890 