### PR TITLE
Downgraded scala 3 version to latest LTS release.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import scala.sys.process.Process
 
 val v2_12 = "2.12.20"
 val v2_13 = "2.13.14"
-val v3 = "3.4.3"
+val v3 = "3.3.4"
 
 lazy val resolvedScalaVersion =
   sys.env.get("SCALA_MAJOR_VERSION") match {


### PR DESCRIPTION
This is to not force never scala 3 versions on clients, as using a never version here, makes the library unusable by clients running the LTS version of scala 3. 