### PR TITLE
Allow MessageGroupId for standard queues

### DIFF
--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/AmazonJavaSdkTestSuite.scala
@@ -445,10 +445,10 @@ class AmazonJavaSdkTestSuite extends SqsClientServerCommunication with Matchers 
       client.sendMessage(new SendMessageRequest(fifoQueueUrl, "A body"))
     )
 
-    // Regular queues don't allow message groups
-    assertInvalidParameterQueueTypeException("MessageGroupId")(
-      client.sendMessage(new SendMessageRequest(regularQueueUrl, "A body").withMessageGroupId("group-1"))
-    )
+    // Regular queues now allow message groups
+    // Test that sending MessageGroupId to regular queue works
+    val result = client.sendMessage(new SendMessageRequest(regularQueueUrl, "A body").withMessageGroupId("group-1"))
+    result should not be null
   }
 
   test("FIFO queues do not support delaying individual messages") {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SendMessageDirectives.scala
@@ -88,17 +88,14 @@ trait SendMessageDirectives {
       .fold(error => throw SQSException.invalidAttributeValue("MessageBody", Some(error)), identity)
 
     val messageGroupId = parameters.MessageGroupId match {
-      // MessageGroupId is only supported for FIFO queues
-      case Some(v) if !queueData.isFifo => throw SQSException.invalidQueueTypeParameter(MessageGroupIdParameter)
-
       // MessageGroupId is required for FIFO queues
       case None if queueData.isFifo => throw SQSException.missingParameter(MessageGroupIdParameter)
 
-      // Ensure the given value is valid
+      // Ensure the given value is valid (for both FIFO and standard queues)
       case Some(id) if !isValidFifoPropertyValue(id) =>
         throw SQSException.invalidAlphanumericalPunctualParameterValue(MessageGroupIdParameter)
 
-      // This must be a correct value (or this isn't a FIFO queue and no value is required)
+      // This must be a correct value or None
       case m => m
     }
 


### PR DESCRIPTION
Remove validation that prevented MessageGroupId from being used with standard (non-FIFO) queues. This aligns ElasticMQ with AWS SQS's new "fair queues" feature that allows MessageGroupId on standard queues.

Fixes #1137