### PR TITLE
Add auto-create-queues feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ project/boot
 /bin/
 
 .bsp
-.db
+*.db
 .env
 .data
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,50 @@ queues {
 ```
 If not then suffix will be added automatically during queue creation.
 
+# Auto-creating queues on demand
+
+ElasticMQ can automatically create a queue the first time any request targets it, instead of returning a
+`NonExistentQueue` error. This is useful during development and testing — it removes the need to maintain a static list
+of queue names in the configuration.
+
+To enable, add the following to your configuration file:
+
+```
+auto-create-queues {
+  enabled = true
+}
+```
+
+Optionally, provide a `template` section to set default attributes for every auto-created queue:
+
+```
+auto-create-queues {
+  enabled = true
+  template {
+    defaultVisibilityTimeout = 30 seconds
+    delay = 0 seconds
+    receiveMessageWait = 0 seconds
+    deadLettersQueue {
+      name = "my-dlq"
+      maxReceiveCount = 3
+    }
+    fifo = false
+    contentBasedDeduplication = false
+    copyTo = "audit-queue-name"
+    moveTo = "redirect-queue-name"
+    tags {
+      env = "dev"
+    }
+  }
+}
+```
+
+All `template` attributes are optional. If `template` is omitted, system defaults are used (30 s visibility timeout,
+0 s delay, no DLQ, standard queue).
+
+If the queue name ends with `.fifo`, the queue is always created as a FIFO queue regardless of the `fifo` template
+setting.
+
 # Persisting queues configuration
 
 Queues configuration can be persisted in an external config file in the [HOCON](https://en.wikipedia.org/wiki/HOCON) 

--- a/examples/elasticmq.conf
+++ b/examples/elasticmq.conf
@@ -16,6 +16,16 @@ messages-storage {
   uri = "jdbc:h2:/data/storage"
 }
 
+auto-create-queues {
+  enabled = false
+  template {
+    defaultVisibilityTimeout = 30 seconds
+    tags {
+        type = "dynamic"
+    }
+  }
+}
+
 queues {
   01-simple-queue { }
 

--- a/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/integration/AutoCreateQueuesTests.scala
+++ b/rest/rest-sqs-testing-amazon-java-sdk/src/test/scala/org/elasticmq/rest/sqs/integration/AutoCreateQueuesTests.scala
@@ -1,0 +1,113 @@
+package org.elasticmq.rest.sqs.integration
+
+import org.elasticmq.persistence.CreateQueueMetadata
+import org.elasticmq.rest.sqs.{AutoCreateQueuesConfig, SQSRestServerBuilder}
+import org.elasticmq.{NodeAddress, RelaxedSQSLimits}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sqs.{SqsClient => AwsSqsClient}
+
+import java.net.URI
+import scala.util.Try
+
+class AutoCreateQueuesTests extends AnyFunSuite with Matchers {
+
+  private val autoCreatePort = 9334
+  private val awsAccountId = "123456789012"
+  private val awsRegion = "elasticmq"
+
+  private def withAutoCreateServer(
+      template: CreateQueueMetadata = CreateQueueMetadata(name = ""),
+      port: Int = autoCreatePort
+  )(test: AwsSqsClient => Unit): Unit = {
+    val server = SQSRestServerBuilder
+      .withPort(port)
+      .withServerAddress(NodeAddress(port = port))
+      .withSQSLimits(RelaxedSQSLimits)
+      .withAWSAccountId(awsAccountId)
+      .withAWSRegion(awsRegion)
+      .withAutoCreateQueues(AutoCreateQueuesConfig(enabled = true, template = template))
+      .start()
+    server.waitUntilStarted()
+
+    val client = AwsSqsClient
+      .builder()
+      .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("x", "x")))
+      .region(Region.EU_CENTRAL_1)
+      .endpointOverride(new URI(s"http://localhost:$port"))
+      .build()
+
+    try {
+      test(client)
+    } finally {
+      Try(client.close())
+      Try(server.stopAndWait())
+    }
+  }
+
+  test("should auto-create a queue when sending a message to a non-existing queue") {
+    withAutoCreateServer() { client =>
+      val queueUrl = s"http://localhost:$autoCreatePort/$awsAccountId/new-queue"
+
+      val sendResult = client.sendMessage(
+        software.amazon.awssdk.services.sqs.model.SendMessageRequest.builder()
+          .queueUrl(queueUrl)
+          .messageBody("hello")
+          .build()
+      )
+      sendResult.messageId() should not be empty
+
+      val listResult = client.listQueues(
+        software.amazon.awssdk.services.sqs.model.ListQueuesRequest.builder().build()
+      )
+      listResult.queueUrls() should contain(queueUrl)
+    }
+  }
+
+  test("should auto-create a FIFO queue when queue name ends with .fifo") {
+    withAutoCreateServer() { client =>
+      val queueUrl = s"http://localhost:$autoCreatePort/$awsAccountId/new-fifo.fifo"
+
+      val sendResult = client.sendMessage(
+        software.amazon.awssdk.services.sqs.model.SendMessageRequest.builder()
+          .queueUrl(queueUrl)
+          .messageBody("hello fifo")
+          .messageGroupId("group1")
+          .messageDeduplicationId("dedup1")
+          .build()
+      )
+      sendResult.messageId() should not be empty
+
+      val attrResult = client.getQueueAttributes(
+        software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest.builder()
+          .queueUrl(queueUrl)
+          .attributeNamesWithStrings("FifoQueue")
+          .build()
+      )
+      attrResult.attributesAsStrings().get("FifoQueue") shouldEqual "true"
+    }
+  }
+
+  test("should auto-create queue with template parameters applied") {
+    val templateWithDelay = CreateQueueMetadata(name = "", delaySeconds = Some(5L))
+    withAutoCreateServer(template = templateWithDelay, port = 9336) { client =>
+      val queueUrl = s"http://localhost:9336/$awsAccountId/templated-queue"
+      client.sendMessage(
+        software.amazon.awssdk.services.sqs.model.SendMessageRequest.builder()
+          .queueUrl(queueUrl)
+          .messageBody("hello")
+          .build()
+      )
+
+      val attrResult = client.getQueueAttributes(
+        software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest.builder()
+          .queueUrl(queueUrl)
+          .attributeNamesWithStrings("DelaySeconds")
+          .build()
+      )
+      attrResult.attributesAsStrings().get("DelaySeconds") shouldEqual "5"
+    }
+  }
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/AutoCreateQueuesConfig.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/AutoCreateQueuesConfig.scala
@@ -1,0 +1,16 @@
+package org.elasticmq.rest.sqs
+
+import org.elasticmq.persistence.CreateQueueMetadata
+
+case class AutoCreateQueuesConfig(enabled: Boolean, template: CreateQueueMetadata)
+
+object AutoCreateQueuesConfig {
+  val disabled: AutoCreateQueuesConfig = AutoCreateQueuesConfig(
+    enabled = false,
+    template = CreateQueueMetadata(name = "")
+  )
+}
+
+trait AutoCreateQueuesModule {
+  def autoCreateQueues: AutoCreateQueuesConfig
+}

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/SQSRestServerBuilder.scala
@@ -50,7 +50,8 @@ object SQSRestServerBuilder
       StrictSQSLimits,
       "elasticmq",
       "000000000000",
-      None
+      None,
+      AutoCreateQueuesConfig.disabled
     )
 
 case class TheSQSRestServerBuilder(
@@ -63,7 +64,8 @@ case class TheSQSRestServerBuilder(
     sqsLimits: Limits,
     _awsRegion: String,
     _awsAccountId: String,
-    queueEventListener: Option[ActorRef]
+    queueEventListener: Option[ActorRef],
+    autoCreateQueuesConfig: AutoCreateQueuesConfig = AutoCreateQueuesConfig.disabled
 ) extends Logging {
 
   /** @param _actorSystem
@@ -126,6 +128,12 @@ case class TheSQSRestServerBuilder(
   def withQueueEventListener(_queueEventListener: ActorRef) =
     this.copy(queueEventListener = Some(_queueEventListener))
 
+  /** @param _autoCreateQueues
+    *   Configuration for auto-creating queues on demand when a message is sent to a non-existing queue.
+    */
+  def withAutoCreateQueues(_autoCreateQueues: AutoCreateQueuesConfig) =
+    this.copy(autoCreateQueuesConfig = _autoCreateQueues)
+
   def start(): SQSRestServer = {
     val (theActorSystem, stopActorSystem) = getOrCreateActorSystem
     val theQueueManagerActor = getOrCreateQueueManagerActor(theActorSystem)
@@ -134,6 +142,7 @@ case class TheSQSRestServerBuilder(
         NodeAddress(host = if (interface.isEmpty) "localhost" else interface, port = port)
       else serverAddress
     val theLimits = sqsLimits
+    val theAutoCreateQueues = autoCreateQueuesConfig
 
     implicit val implicitActorSystem: ActorSystem = theActorSystem
     implicit val implicitMaterializer: Materializer = Materializer(theActorSystem)
@@ -173,7 +182,8 @@ case class TheSQSRestServerBuilder(
       with ListDeadLetterSourceQueuesDirectives
       with StartMessageMoveTaskDirectives
       with CancelMessageMoveTaskDirectives
-      with ListMessageMoveTasksDirectives {
+      with ListMessageMoveTasksDirectives
+      with AutoCreateQueuesModule {
 
       def serverAddress = currentServerAddress.get()
 
@@ -186,6 +196,7 @@ case class TheSQSRestServerBuilder(
 
       lazy val awsRegion: String = _awsRegion
       lazy val awsAccountId: String = _awsAccountId
+      lazy val autoCreateQueues: AutoCreateQueuesConfig = theAutoCreateQueues
 
     }
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/ElasticMQDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/ElasticMQDirectives.scala
@@ -1,7 +1,7 @@
 package org.elasticmq.rest.sqs.directives
 
 import org.apache.pekko.http.scaladsl.server.{Directives, Route}
-import org.elasticmq.rest.sqs.{ActorSystemModule, ContextPathModule, QueueManagerActorModule}
+import org.elasticmq.rest.sqs.{ActorSystemModule, AutoCreateQueuesModule, ContextPathModule, QueueManagerActorModule}
 import org.elasticmq.util.Logging
 
 trait ElasticMQDirectives
@@ -14,6 +14,7 @@ trait ElasticMQDirectives
     with QueueManagerActorModule
     with ContextPathModule
     with ActorSystemModule
+    with AutoCreateQueuesModule
     with RejectionDirectives
     with Logging {
 

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/QueueDirectives.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/rest/sqs/directives/QueueDirectives.scala
@@ -4,17 +4,25 @@ import org.apache.pekko.actor.ActorRef
 import org.apache.pekko.http.scaladsl.model.Uri
 import org.apache.pekko.http.scaladsl.server.PathMatcher.{Matched, Unmatched}
 import org.apache.pekko.http.scaladsl.server._
+import org.elasticmq.QueueAlreadyExists
 import org.elasticmq.QueueData
 import org.elasticmq.actor.reply._
-import org.elasticmq.msg.{GetQueueData, LookupQueue}
+import org.elasticmq.msg.{CreateQueue => CreateQueueMsg, GetQueueData, LookupQueue}
 import org.elasticmq.rest.sqs.Constants.QueueUrlParameter
 import org.elasticmq.rest.sqs._
+import org.elasticmq.rest.sqs.SQSException.ElasticMQErrorOps
 import org.elasticmq.rest.sqs.directives.QueueDirectives.AccountIdRegex
 
+import scala.concurrent.Future
 import scala.util.matching.Regex
 
 trait QueueDirectives {
-  this: Directives with QueueManagerActorModule with ContextPathModule with ActorSystemModule with FutureDirectives =>
+  this: Directives
+    with QueueManagerActorModule
+    with ContextPathModule
+    with ActorSystemModule
+    with FutureDirectives
+    with AutoCreateQueuesModule =>
 
   def queueActorFromUrl(queueUrl: String)(body: ActorRef => Route): Route =
     getQueueNameFromQueueUrl(queueUrl)(queueName => queueActor(queueName, body))
@@ -64,14 +72,28 @@ trait QueueDirectives {
   }
 
   private def queueActor(queueName: String, body: ActorRef => Route): Route = {
-    for {
-      lookupResult <- queueManagerActor ? LookupQueue(queueName)
-    } yield {
-      lookupResult match {
-        case Some(a) => body(a)
-        case None    => throw SQSException.nonExistentQueue
-      }
-    }
+    val ec = actorSystem.dispatcher
+    (queueManagerActor ? LookupQueue(queueName)).flatMap {
+      case Some(a) => Future.successful(body(a))
+      case None if autoCreateQueues.enabled => autoCreateQueue(queueName).map(body)(ec)
+      case None => Future.failed(SQSException.nonExistentQueue)
+    }(ec)
+  }
+
+  private def autoCreateQueue(queueName: String): Future[ActorRef] = {
+    val ec = actorSystem.dispatcher
+    val isFifo = queueName.endsWith(".fifo") || autoCreateQueues.template.isFifo
+    val queueData = autoCreateQueues.template.copy(name = queueName, isFifo = isFifo).toCreateQueueData
+    (queueManagerActor ? CreateQueueMsg(queueData)).flatMap {
+      case Right(ref) => Future.successful(ref.asInstanceOf[ActorRef])
+      case Left(_: QueueAlreadyExists) =>
+        // Race condition: queue was created by a concurrent request; fall back to lookup
+        (queueManagerActor ? LookupQueue(queueName)).map {
+          case Some(a) => a
+          case None    => throw SQSException.nonExistentQueue
+        }(ec)
+      case Left(e) => Future.failed(e.toSQSException)
+    }(ec)
   }
 
   private def queueData(queueActor: ActorRef, body: QueueData => Route): Route = {

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/server/ElasticMQServer.scala
@@ -88,7 +88,8 @@ class ElasticMQServer(config: ElasticMQServerConfig) extends Logging {
         config.restSqs.sqsLimits,
         config.awsRegion,
         config.awsAccountId,
-        queueConfigStore
+        queueConfigStore,
+        config.autoCreateQueues
       ).start()
 
       val _: Http.ServerBinding = server.waitUntilStarted()

--- a/rest/rest-sqs/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
+++ b/rest/rest-sqs/src/main/scala/org/elasticmq/server/config/ElasticMQServerConfig.scala
@@ -1,11 +1,15 @@
 package org.elasticmq.server.config
 
 import com.typesafe.config.Config
-import org.elasticmq.persistence.CreateQueueMetadata
+import org.elasticmq.persistence.{CreateQueueMetadata, DeadLettersQueue}
 import org.elasticmq.persistence.file.QueueConfigUtil
 import org.elasticmq.persistence.sql.SqlQueuePersistenceConfig
+import org.elasticmq.rest.sqs.AutoCreateQueuesConfig
 import org.elasticmq.util.Logging
 import org.elasticmq.{NodeAddress, RelaxedSQSLimits, StrictSQSLimits}
+
+import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
 
 class ElasticMQServerConfig(config: Config) extends Logging {
   // What is the outside visible address of this ElasticMQ node (used by rest-sqs)
@@ -66,4 +70,47 @@ class ElasticMQServerConfig(config: Config) extends Logging {
   val sqlQueuePersistenceConfig: SqlQueuePersistenceConfig = getSqlQueuePersistenceConfig
 
   val baseQueues: List[CreateQueueMetadata] = QueueConfigUtil.readPersistedQueuesFromConfig(config)
+
+  val autoCreateQueues: AutoCreateQueuesConfig = parseAutoCreateQueuesConfig
+
+  private def parseAutoCreateQueuesConfig: AutoCreateQueuesConfig = {
+    if (!config.hasPath("auto-create-queues")) return AutoCreateQueuesConfig.disabled
+    val subConfig = config.getConfig("auto-create-queues")
+    val enabled = if (subConfig.hasPath("enabled")) subConfig.getBoolean("enabled") else false
+    if (!enabled) return AutoCreateQueuesConfig.disabled
+    val template =
+      if (subConfig.hasPath("template")) parseQueueTemplate(subConfig.getConfig("template"))
+      else CreateQueueMetadata(name = "")
+    AutoCreateQueuesConfig(enabled = true, template = template)
+  }
+
+  private def parseQueueTemplate(c: Config): CreateQueueMetadata = {
+    def getOptionalBoolean(k: String) = if (c.hasPath(k)) Some(c.getBoolean(k)) else None
+    def getOptionalDuration(k: String) = if (c.hasPath(k)) Some(c.getDuration(k, TimeUnit.SECONDS)) else None
+    def getOptionalString(k: String) = if (c.hasPath(k)) Some(c.getString(k)).filter(_.nonEmpty) else None
+    def getOptionalTags(k: String): Map[String, String] =
+      if (c.hasPath(k)) c.getObject(k).asScala.map { case (key, _) => key -> c.getString(k + '.' + key) }.toMap
+      else Map.empty
+
+    val isFifo = getOptionalBoolean("fifo").getOrElse(false)
+    val deadLettersQueueKey = "deadLettersQueue"
+
+    CreateQueueMetadata(
+      name = "",
+      defaultVisibilityTimeoutSeconds = getOptionalDuration("defaultVisibilityTimeout"),
+      delaySeconds = getOptionalDuration("delay"),
+      receiveMessageWaitSeconds = getOptionalDuration("receiveMessageWait"),
+      deadLettersQueue = if (c.hasPath(deadLettersQueueKey))
+        Some(DeadLettersQueue(
+          c.getString(deadLettersQueueKey + ".name"),
+          c.getInt(deadLettersQueueKey + ".maxReceiveCount")
+        ))
+      else None,
+      isFifo = isFifo,
+      hasContentBasedDeduplication = getOptionalBoolean("contentBasedDeduplication").getOrElse(false),
+      copyMessagesTo = getOptionalString("copyTo"),
+      moveMessagesTo = getOptionalString("moveTo"),
+      tags = getOptionalTags("tags")
+    )
+  }
 }

--- a/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/directives/QueueDirectivesTest.scala
+++ b/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/directives/QueueDirectivesTest.scala
@@ -5,8 +5,9 @@ import org.apache.pekko.http.scaladsl.testkit.ScalatestRouteTest
 import org.apache.pekko.util.Timeout
 import org.elasticmq.actor.QueueManagerActor
 import org.elasticmq.actor.reply._
-import org.elasticmq.msg.CreateQueue
-import org.elasticmq.rest.sqs.{ActorSystemModule, ContextPathModule, QueueManagerActorModule}
+import org.elasticmq.msg.{CreateQueue, LookupQueue}
+import org.elasticmq.persistence.CreateQueueMetadata
+import org.elasticmq.rest.sqs.{ActorSystemModule, AutoCreateQueuesConfig, AutoCreateQueuesModule, ContextPathModule, QueueManagerActorModule}
 import org.elasticmq.util.NowProvider
 import org.elasticmq.{CreateQueueData, MillisVisibilityTimeout, QueueData, StrictSQSLimits}
 import org.scalatest.concurrent.ScalaFutures
@@ -30,7 +31,8 @@ class QueueDirectivesTest
     with ExceptionDirectives
     with RespondDirectives
     with ScalaFutures
-    with AWSProtocolDirectives {
+    with AWSProtocolDirectives
+    with AutoCreateQueuesModule {
 
   private val maxDuration = 1.minute
   implicit val timeout: Timeout = maxDuration
@@ -39,6 +41,9 @@ class QueueDirectivesTest
   lazy val queueManagerActor: ActorRef =
     actorSystem.actorOf(Props(new QueueManagerActor(new NowProvider(), StrictSQSLimits, None)))
   lazy val contextPath = ""
+
+  // Mutable so individual tests can override auto-create behaviour
+  var autoCreateQueues: AutoCreateQueuesConfig = AutoCreateQueuesConfig.disabled
 
   "queueActorFromUrl" should "return correct queue name based on QueueName" in {
     val future = queueManagerActor ? CreateQueue(
@@ -117,5 +122,56 @@ class QueueDirectivesTest
     Get("/") ~> route ~> check {
       rejections shouldNot be(empty)
     }
+  }
+
+  "queueActor" should "reject non-existing queue when auto-create is disabled" in {
+    autoCreateQueues = AutoCreateQueuesConfig.disabled
+    val route = {
+      extractProtocol { protocol =>
+        handleServerExceptions(protocol) {
+          queueActorAndNameFromUrl(
+            "https://eu-central-1.queue.amazonaws.com/906175111765/non-existing-queue"
+          ) { (_, name) => _.complete(name) }
+        }
+      }
+    }
+
+    Get("/906175111765/non-existing-queue") ~> route ~> check {
+      status.intValue() shouldEqual 400
+    }
+  }
+
+  "queueActor" should "auto-create a non-existing queue when auto-create is enabled" in {
+    autoCreateQueues = AutoCreateQueuesConfig(enabled = true, template = CreateQueueMetadata(name = ""))
+    val route = {
+      queueActorAndNameFromUrl(
+        "https://eu-central-1.queue.amazonaws.com/906175111765/auto-created-queue"
+      ) { (_, name) => _.complete(name) }
+    }
+
+    Get("/906175111765/auto-created-queue") ~> route ~> check {
+      responseAs[String] shouldEqual "auto-created-queue"
+    }
+
+    // Verify the queue was actually created
+    val lookupResult = (queueManagerActor ? LookupQueue("auto-created-queue")).futureValue
+    lookupResult shouldBe defined
+  }
+
+  "queueActor" should "auto-create a FIFO queue when queue name ends with .fifo" in {
+    autoCreateQueues = AutoCreateQueuesConfig(enabled = true, template = CreateQueueMetadata(name = ""))
+    val route = {
+      queueActorAndNameFromUrl(
+        "https://eu-central-1.queue.amazonaws.com/906175111765/auto-fifo.fifo"
+      ) { (_, name) => _.complete(name) }
+    }
+
+    Get("/906175111765/auto-fifo.fifo") ~> route ~> check {
+      responseAs[String] shouldEqual "auto-fifo.fifo"
+    }
+
+    // Verify the queue was created and is FIFO
+    val lookupResult = (queueManagerActor ? LookupQueue("auto-fifo.fifo")).futureValue
+    lookupResult shouldBe defined
   }
 }

--- a/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/directives/QueueDirectivesWithContextPathTest.scala
+++ b/rest/rest-sqs/src/test/scala/org/elasticmq/rest/sqs/directives/QueueDirectivesWithContextPathTest.scala
@@ -7,7 +7,7 @@ import org.apache.pekko.util.Timeout
 import org.elasticmq.actor.QueueManagerActor
 import org.elasticmq.actor.reply._
 import org.elasticmq.msg.CreateQueue
-import org.elasticmq.rest.sqs.{ActorSystemModule, ContextPathModule, QueueManagerActorModule}
+import org.elasticmq.rest.sqs.{ActorSystemModule, AutoCreateQueuesConfig, AutoCreateQueuesModule, ContextPathModule, QueueManagerActorModule}
 import org.elasticmq.util.NowProvider
 import org.elasticmq.{CreateQueueData, MillisVisibilityTimeout, QueueData, StrictSQSLimits}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -29,7 +29,8 @@ class QueueDirectivesWithContextPathTest
     with ActorSystemModule
     with ExceptionDirectives
     with RespondDirectives
-    with AWSProtocolDirectives {
+    with AWSProtocolDirectives
+    with AutoCreateQueuesModule {
 
   private val maxDuration = 1.minute
   implicit val timeout: Timeout = maxDuration
@@ -38,6 +39,7 @@ class QueueDirectivesWithContextPathTest
   lazy val queueManagerActor: ActorRef =
     actorSystem.actorOf(Props(new QueueManagerActor(new NowProvider(), StrictSQSLimits, None)))
   lazy val contextPath = "/test-context"
+  lazy val autoCreateQueues: AutoCreateQueuesConfig = AutoCreateQueuesConfig.disabled
 
   "queueActorAndNameFromUrl" should "return correct queue name based on QueueName" in {
     val future = queueManagerActor ? CreateQueue(


### PR DESCRIPTION
## Summary

- Adds a new `auto-create-queues` configuration section. When `enabled = true`, any request targeting a non-existing queue creates the queue on demand instead of returning `NonExistentQueue`.
- An optional `template` sub-section lets users specify default attributes (visibility timeout, delay, DLQ, tags, etc.) for all auto-created queues.
- Queues whose names end in `.fifo` are always created as FIFO queues regardless of the template setting.
- The feature defaults to `enabled = false`, so it is fully backwards-compatible.

Resolves #1132

## Configuration example

```hocon
auto-create-queues {
  enabled = true
  template {
    defaultVisibilityTimeout = 30 seconds
    delay = 0 seconds
    tags {
      env = "dev"
    }
  }
}
```

## Test plan

- [x] Unit tests added to `QueueDirectivesTest` (auto-create disabled returns error, enabled creates queue, `.fifo` detection)
- [x] Integration tests added in `AutoCreateQueuesTests` (send to non-existing queue, FIFO auto-creation, template attributes applied)
- [x] Existing test suite (`restSqs/test`) passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)