### PR TITLE
UI: support real AWS accounts, add auto-refresh feature flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,14 +164,33 @@ npm run lint
 
 ### Environment Variables
 
-**File:** `ui/.env.local` (gitignored)
+**File:** `ui/.env.local` (gitignored) — copy from `ui/.env.local.example`.
 
+**Local ElasticMQ (default):**
 ```bash
 SQS_ENDPOINT=http://localhost:9324
 AWS_REGION=elasticmq
 AWS_ACCESS_KEY_ID=x
 AWS_SECRET_ACCESS_KEY=x
 ```
+
+**Real AWS account:**
+```bash
+# SQS_ENDPOINT is omitted — SDK defaults to the real AWS endpoint
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+# Disable auto-refresh to avoid unnecessary API calls and costs:
+NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true
+```
+
+The IAM credentials need `sqs:ListQueues`, `sqs:GetQueueAttributes`, and `sqs:GetQueueUrl` permissions to browse queues, plus write permissions (`sqs:SendMessage`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:CreateQueue`, `sqs:DeleteQueue`) for the full feature set.
+
+**Feature flags:**
+
+| Variable | Values | Default | Description |
+|----------|--------|---------|-------------|
+| `NEXT_PUBLIC_AUTO_REFRESH_DISABLED` | `true` / unset | disabled (auto-refresh on) | Disables the 1-second polling. Recommended when pointing at real AWS to avoid API costs. The UI switches from a pulsing live indicator to a static "Manual" label. |
 
 ### Architecture Patterns
 
@@ -183,7 +202,7 @@ AWS_SECRET_ACCESS_KEY=x
 - `getQueues()` — list all queues with attributes
 - `getQueueDetails(queueName)` — single queue details
 
-**Polling:** Client components poll server actions every 1 second.
+**Polling:** Client components poll server actions every 1 second (disabled when `NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true`).
 
 **SQS Client Config:**
 ```typescript

--- a/README.md
+++ b/README.md
@@ -541,14 +541,25 @@ npm install
 npm run dev
 ```
 
-The dev server starts at **http://localhost:3000** and expects ElasticMQ running at `http://localhost:9324`. Configure the endpoint in `ui/.env.local` if needed:
+The dev server starts at **http://localhost:3000** and expects ElasticMQ running at `http://localhost:9324`. Configure the endpoint in `ui/.env.local` (copy from `ui/.env.local.example`) if needed.
+
+**Pointing the UI at a real AWS account** is also supported — the UI uses the standard AWS SDK and works with any SQS-compatible endpoint. Set your credentials and region in `ui/.env.local` and leave `SQS_ENDPOINT` unset so the SDK defaults to the real AWS endpoint:
 
 ```bash
-SQS_ENDPOINT=http://localhost:9324
-AWS_REGION=elasticmq
-AWS_ACCESS_KEY_ID=x
-AWS_SECRET_ACCESS_KEY=x
+# ui/.env.local — real AWS example
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true
 ```
+
+The credentials need at minimum `sqs:ListQueues` and `sqs:GetQueueAttributes` for read-only access, plus `sqs:SendMessage`, `sqs:ReceiveMessage`, `sqs:DeleteMessage`, `sqs:CreateQueue`, and `sqs:DeleteQueue` for full functionality.
+
+**Feature flags** (set in `ui/.env.local`):
+
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true` | Disables the automatic 1-second state refresh. Recommended when pointing at real AWS to avoid unnecessary API calls and costs. The UI switches from a pulsing live indicator to a static "Manual" label; the Refresh button continues to work. |
 
 # MBeans
 

--- a/ui/.env.local.example
+++ b/ui/.env.local.example
@@ -1,0 +1,19 @@
+# ElasticMQ UI — Environment Configuration
+# Copy this file to .env.local and fill in the values.
+
+# ── Option A: Local ElasticMQ instance (default) ──────────────────────────────
+SQS_ENDPOINT=http://localhost:9324
+AWS_REGION=elasticmq
+AWS_ACCESS_KEY_ID=x
+AWS_SECRET_ACCESS_KEY=x
+
+# ── Option B: Real AWS account ────────────────────────────────────────────────
+# Leave SQS_ENDPOINT unset — the SDK will route to the real AWS SQS endpoint.
+# AWS_REGION=us-east-1
+# AWS_ACCESS_KEY_ID=AKIA...
+# AWS_SECRET_ACCESS_KEY=...
+
+# ── Feature flags ─────────────────────────────────────────────────────────────
+# Disable the automatic 1-second state refresh. Recommended when pointing the
+# UI at a real AWS account to avoid unnecessary API calls (and costs).
+# NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env*.example
 
 # vercel
 .vercel

--- a/ui/components/queue-details.tsx
+++ b/ui/components/queue-details.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react';
+
+const autoRefreshDisabled = process.env.NEXT_PUBLIC_AUTO_REFRESH_DISABLED === 'true';
 import { useRouter } from 'next/navigation';
 import { QueueData } from '@/lib/types';
 import { ArrowLeft, RefreshCw, ArrowDown, Zap, ArrowUp, Trash2 } from 'lucide-react';
@@ -48,6 +50,7 @@ export function QueueDetails({ queueName }: QueueDetailsProps) {
 
   useEffect(() => {
     fetchQueueDetails();
+    if (autoRefreshDisabled) return;
     const interval = setInterval(() => fetchQueueDetails(), 1000);
     return () => clearInterval(interval);
   }, [fetchQueueDetails]);
@@ -116,12 +119,12 @@ export function QueueDetails({ queueName }: QueueDetailsProps) {
             <p style={{ fontSize: 11, color: 'var(--muted)', marginLeft: 12, letterSpacing: '0.02em' }}>
               <span style={{
                 display: 'inline-block', width: 6, height: 6, borderRadius: '50%',
-                background: 'var(--green)',
+                background: autoRefreshDisabled ? 'var(--muted)' : 'var(--green)',
                 marginRight: 5, verticalAlign: 'middle',
-                boxShadow: '0 0 4px var(--green)',
-                animation: 'pulse-dot 2s ease-in-out infinite',
+                boxShadow: autoRefreshDisabled ? 'none' : '0 0 4px var(--green)',
+                animation: autoRefreshDisabled ? 'none' : 'pulse-dot 2s ease-in-out infinite',
               }} />
-              Live · {lastUpdate.toLocaleTimeString()}
+              {autoRefreshDisabled ? `Manual · ${lastUpdate.toLocaleTimeString()}` : `Live · ${lastUpdate.toLocaleTimeString()}`}
             </p>
           )}
         </div>

--- a/ui/components/queue-list.tsx
+++ b/ui/components/queue-list.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState, useEffect } from 'react';
+
+const autoRefreshDisabled = process.env.NEXT_PUBLIC_AUTO_REFRESH_DISABLED === 'true';
 import { QueueData } from '@/lib/types';
 import { getQueues } from '@/lib/actions';
 import { QueueCard } from './queue-card';
@@ -34,6 +36,7 @@ export function QueueList() {
 
   useEffect(() => {
     fetchQueues();
+    if (autoRefreshDisabled) return;
     const interval = setInterval(() => fetchQueues(), 1000);
     return () => clearInterval(interval);
   }, []);
@@ -88,16 +91,16 @@ export function QueueList() {
         {/* Toolbar */}
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            {/* Live dot */}
+            {/* Live/static dot */}
             <span style={{
               display: 'inline-block', width: 7, height: 7, borderRadius: '50%',
-              background: 'var(--green)',
-              boxShadow: '0 0 6px var(--green)',
-              animation: 'pulse-dot 2s ease-in-out infinite',
+              background: autoRefreshDisabled ? 'var(--muted)' : 'var(--green)',
+              boxShadow: autoRefreshDisabled ? 'none' : '0 0 6px var(--green)',
+              animation: autoRefreshDisabled ? 'none' : 'pulse-dot 2s ease-in-out infinite',
             }} />
             <span style={{ fontSize: 12, color: 'var(--muted)', fontVariantNumeric: 'tabular-nums' }}>
               {queues.length} queue{queues.length !== 1 ? 's' : ''}
-              {lastUpdate && ` · ${lastUpdate.toLocaleTimeString()}`}
+              {lastUpdate && ` · ${autoRefreshDisabled ? 'manual' : lastUpdate.toLocaleTimeString()}`}
             </span>
           </div>
 

--- a/ui/lib/sqs-client.ts
+++ b/ui/lib/sqs-client.ts
@@ -1,7 +1,7 @@
 import { SQSClient } from '@aws-sdk/client-sqs';
 
 export const sqsClient = new SQSClient({
-  endpoint: process.env.SQS_ENDPOINT || 'http://localhost:9324',
+  ...(process.env.SQS_ENDPOINT ? { endpoint: process.env.SQS_ENDPOINT } : {}),
   region: process.env.AWS_REGION || 'elasticmq',
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'x',


### PR DESCRIPTION
## Summary

- Fix `sqs-client.ts` to omit `endpoint` when `SQS_ENDPOINT` is unset, so the AWS SDK routes to the real AWS SQS endpoint (previously it always fell back to `localhost:9324`)
- Add `NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true` feature flag to disable 1-second polling — recommended when pointing at a real AWS account to avoid unnecessary API costs; the UI shows a static grey "Manual" indicator instead of the pulsing green live dot
- Add `ui/.env.local.example` documenting both local ElasticMQ and real AWS configurations, and unignore `*.example` env files in `ui/.gitignore`
- Document AWS usage, required IAM permissions, and the feature flag in `README.md` and `CLAUDE.md`

## Test plan

- [ ] Local ElasticMQ: `SQS_ENDPOINT=http://localhost:9324` in `.env.local` — polling works, live green dot pulses
- [ ] Real AWS: `SQS_ENDPOINT` unset, real credentials in `.env.local` — queues from AWS account are listed
- [ ] `NEXT_PUBLIC_AUTO_REFRESH_DISABLED=true`: no polling, static grey dot, "Manual" label shown, Refresh button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)